### PR TITLE
Quaternion fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Reorder euler angles in quaternion conversions from `(yaw, pitch, roll)` to
+  `(pitch, yaw, roll)` to be consistent with the ordering in matrix conversions.
+- Base the `Rotation::from_angle_{x, y, z}` default implementations off
+  `Rotation::from_euler` as opposed to `Rotation::from_axis_angle`.
+- Fix implementation of `Quaternion::from_axis_angle`
+
 ## [v0.7.0] - 2015-12-23
 
 ### Added

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -241,20 +241,20 @@ impl<S: BaseFloat> Quaternion<S> {
 
         if test > sig * unit {
             (
-                Rad::zero(),
                 Rad::turn_div_4(),
+                Rad::zero(),
                 Rad::atan2(qx, qw) * two,
             )
         } else if test < -sig * unit {
             (
-                Rad::zero(),
                 -Rad::turn_div_4(),
+                Rad::zero(),
                 Rad::atan2(qx, qw) * two,
             )
         } else {
             (
-                Rad::atan2(two * (qy * qw - qx * qz), one - two * (sqy + sqz)),
                 Rad::asin(two * (qx * qy + qz * qw)),
+                Rad::atan2(two * (qy * qw - qx * qz), one - two * (sqy + sqz)),
                 Rad::atan2(two * (qx * qw - qy * qz), one - two * (sqx + sqz)),
             )
         }
@@ -368,17 +368,27 @@ impl<S: BaseFloat> Rotation3<S> for Quaternion<S> {
         Quaternion::from_sv(c, axis * s)
     }
 
+    /// Create a quaternion from a set of euler angles.
+    ///
+    /// # Parameters
+    ///
+    /// - `x`: the angular rotation around the `x` axis (pitch).
+    /// - `y`: the angular rotation around the `y` axis (yaw).
+    /// - `z`: the angular rotation around the `z` axis (roll).
+    ///
+    /// # References
+    ///
     /// - [Maths - Conversion Euler to Quaternion]
     ///   (http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/index.htm)
     fn from_euler(x: Rad<S>, y: Rad<S>, z: Rad<S>) -> Quaternion<S> {
-        let (s1, c1) = Rad::sin_cos(x * cast(0.5f64).unwrap());
-        let (s2, c2) = Rad::sin_cos(y * cast(0.5f64).unwrap());
-        let (s3, c3) = Rad::sin_cos(z * cast(0.5f64).unwrap());
+        let (s_x, c_x) = Rad::sin_cos(x * cast(0.5f64).unwrap());
+        let (s_y, c_y) = Rad::sin_cos(y * cast(0.5f64).unwrap());
+        let (s_z, c_z) = Rad::sin_cos(z * cast(0.5f64).unwrap());
 
-        Quaternion::new(c1 * c2 * c3 - s1 * s2 * s3,
-                        s1 * s2 * c3 + c1 * c2 * s3,
-                        s1 * c2 * c3 + c1 * s2 * s3,
-                        c1 * s2 * c3 - s1 * c2 * s3)
+        Quaternion::new(c_y * c_x * c_z - s_y * s_x * s_z,
+                        s_y * s_x * c_z + c_y * c_x * s_z,
+                        s_y * c_x * c_z + c_y * s_x * s_z,
+                        c_y * s_x * c_z - s_y * c_x * s_z)
     }
 }
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -365,6 +365,7 @@ impl<S: BaseFloat> Rotation3<S> for Quaternion<S> {
     #[inline]
     fn from_axis_angle(axis: Vector3<S>, angle: Rad<S>) -> Quaternion<S> {
         let (s, c) = Rad::sin_cos(angle * cast(0.5f64).unwrap());
+        let axis = Vector3::new(axis.z, axis.y, axis.x); // Fix ordering to match pitch, yaw, roll
         Quaternion::from_sv(c, axis * s)
     }
 

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -98,19 +98,19 @@ pub trait Rotation3<S: BaseFloat>: Rotation<Point3<S>>
     /// Create a rotation from an angle around the `x` axis (pitch).
     #[inline]
     fn from_angle_x(theta: Rad<S>) -> Self {
-        Rotation3::from_axis_angle(Vector3::unit_x(), theta)
+        Rotation3::from_euler(theta, Rad::zero(), Rad::zero())
     }
 
     /// Create a rotation from an angle around the `y` axis (yaw).
     #[inline]
     fn from_angle_y(theta: Rad<S>) -> Self {
-        Rotation3::from_axis_angle(Vector3::unit_y(), theta)
+        Rotation3::from_euler(Rad::zero(), theta, Rad::zero())
     }
 
     /// Create a rotation from an angle around the `z` axis (roll).
     #[inline]
     fn from_angle_z(theta: Rad<S>) -> Self {
-        Rotation3::from_axis_angle(Vector3::unit_z(), theta)
+        Rotation3::from_euler(Rad::zero(), Rad::zero(), theta)
     }
 }
 

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -45,6 +45,53 @@ mod to_from_euler {
     #[test] fn test_pitch_yaw_roll_neg_hp() { check_euler(rad(0.0), rad(-HPI), rad(1.0)); }
 }
 
+mod from_axis_angle {
+    mod axis_x {
+        use cgmath::*;
+
+        fn check_from_axis_angle(pitch: Rad<f32>) {
+            let found = Quaternion::from_axis_angle(Vector3::unit_x(), pitch);
+            let expected = Quaternion::from_euler(pitch, rad(0.0), rad(0.0));
+
+            assert_approx_eq_eps!(found, expected, 0.001);
+        }
+
+        #[test] fn test_zero()      { check_from_axis_angle(rad(0.0)); }
+        #[test] fn test_pos_1()     { check_from_axis_angle(rad(1.0)); }
+        #[test] fn test_neg_1()     { check_from_axis_angle(rad(-1.0)); }
+    }
+
+    mod axis_y {
+        use cgmath::*;
+
+        fn check_from_axis_angle(yaw: Rad<f32>) {
+            let found = Quaternion::from_axis_angle(Vector3::unit_y(), yaw);
+            let expected = Quaternion::from_euler(rad(0.0), yaw, rad(0.0));
+
+            assert_approx_eq_eps!(found, expected, 0.001);
+        }
+
+        #[test] fn test_zero()      { check_from_axis_angle(rad(0.0)); }
+        #[test] fn test_pos_1()     { check_from_axis_angle(rad(1.0)); }
+        #[test] fn test_neg_1()     { check_from_axis_angle(rad(-1.0)); }
+    }
+
+    mod axis_z {
+        use cgmath::*;
+
+        fn check_from_axis_angle(roll: Rad<f32>) {
+            let found = Quaternion::from_axis_angle(Vector3::unit_z(), roll);
+            let expected = Quaternion::from_euler(rad(0.0), rad(0.0), roll);
+
+            assert_approx_eq_eps!(found, expected, 0.001);
+        }
+
+        #[test] fn test_zero()      { check_from_axis_angle(rad(0.0)); }
+        #[test] fn test_pos_1()     { check_from_axis_angle(rad(1.0)); }
+        #[test] fn test_neg_1()     { check_from_axis_angle(rad(-1.0)); }
+    }
+}
+
 mod from_angle_x {
     use cgmath::*;
 

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -32,17 +32,17 @@ mod to_from_euler {
 
     const HPI: f32 = f32::consts::FRAC_PI_2;
 
-    #[test] fn test_zero()                  { check_euler(rad(0f32), rad(0f32), rad(0f32)); }
-    #[test] fn test_yaw_pos_1()             { check_euler(rad(0f32), rad(1f32), rad(0f32)); }
-    #[test] fn test_yaw_neg_1()             { check_euler(rad(0f32), rad(-1f32), rad(0f32)); }
-    #[test] fn test_pitch_pos_1()           { check_euler(rad(1f32), rad(0f32), rad(0f32)); }
-    #[test] fn test_pitch_neg_1()           { check_euler(rad(-1f32), rad(0f32), rad(0f32)); }
-    #[test] fn test_roll_pos_1()            { check_euler(rad(0f32), rad(0f32), rad(1f32)); }
-    #[test] fn test_roll_neg_1()            { check_euler(rad(0f32), rad(0f32), rad(-1f32)); }
-    #[test] fn test_pitch_yaw_roll_pos_1()  { check_euler(rad(1f32), rad(1f32), rad(1f32)); }
-    #[test] fn test_pitch_yaw_roll_neg_1()  { check_euler(rad(-1f32), rad(-1f32), rad(-1f32)); }
-    #[test] fn test_pitch_yaw_roll_pos_hp() { check_euler(rad(0f32), rad(HPI), rad(1f32)); }
-    #[test] fn test_pitch_yaw_roll_neg_hp() { check_euler(rad(0f32), rad(-HPI), rad(1f32)); }
+    #[test] fn test_zero()                  { check_euler(rad(0.0), rad(0.0), rad(0.0)); }
+    #[test] fn test_yaw_pos_1()             { check_euler(rad(0.0), rad(1.0), rad(0.0)); }
+    #[test] fn test_yaw_neg_1()             { check_euler(rad(0.0), rad(-1.0), rad(0.0)); }
+    #[test] fn test_pitch_pos_1()           { check_euler(rad(1.0), rad(0.0), rad(0.0)); }
+    #[test] fn test_pitch_neg_1()           { check_euler(rad(-1.0), rad(0.0), rad(0.0)); }
+    #[test] fn test_roll_pos_1()            { check_euler(rad(0.0), rad(0.0), rad(1.0)); }
+    #[test] fn test_roll_neg_1()            { check_euler(rad(0.0), rad(0.0), rad(-1.0)); }
+    #[test] fn test_pitch_yaw_roll_pos_1()  { check_euler(rad(1.0), rad(1.0), rad(1.0)); }
+    #[test] fn test_pitch_yaw_roll_neg_1()  { check_euler(rad(-1.0), rad(-1.0), rad(-1.0)); }
+    #[test] fn test_pitch_yaw_roll_pos_hp() { check_euler(rad(0.0), rad(HPI), rad(1.0)); }
+    #[test] fn test_pitch_yaw_roll_neg_hp() { check_euler(rad(0.0), rad(-HPI), rad(1.0)); }
 }
 
 mod from_angle_x {
@@ -55,9 +55,9 @@ mod from_angle_x {
         assert_approx_eq_eps!(found, expected, 0.001);
     }
 
-    #[test] fn test_zero()      { check_from_angle_x(rad(0f32)); }
-    #[test] fn test_pos_1()     { check_from_angle_x(rad(1f32)); }
-    #[test] fn test_neg_1()     { check_from_angle_x(rad(-1f32)); }
+    #[test] fn test_zero()      { check_from_angle_x(rad(0.0)); }
+    #[test] fn test_pos_1()     { check_from_angle_x(rad(1.0)); }
+    #[test] fn test_neg_1()     { check_from_angle_x(rad(-1.0)); }
 }
 
 mod from_angle_y {
@@ -70,9 +70,9 @@ mod from_angle_y {
         assert_approx_eq_eps!(found, expected, 0.001);
     }
 
-    #[test] fn test_zero()      { check_from_angle_y(rad(0f32)); }
-    #[test] fn test_pos_1()     { check_from_angle_y(rad(1f32)); }
-    #[test] fn test_neg_1()     { check_from_angle_y(rad(-1f32)); }
+    #[test] fn test_zero()      { check_from_angle_y(rad(0.0)); }
+    #[test] fn test_pos_1()     { check_from_angle_y(rad(1.0)); }
+    #[test] fn test_neg_1()     { check_from_angle_y(rad(-1.0)); }
 }
 
 mod from_angle_z {
@@ -85,9 +85,9 @@ mod from_angle_z {
         assert_approx_eq_eps!(found, expected, 0.001);
     }
 
-    #[test] fn test_zero()      { check_from_angle_z(rad(0f32)); }
-    #[test] fn test_pos_1()     { check_from_angle_z(rad(1f32)); }
-    #[test] fn test_neg_1()     { check_from_angle_z(rad(-1f32)); }
+    #[test] fn test_zero()      { check_from_angle_z(rad(0.0)); }
+    #[test] fn test_pos_1()     { check_from_angle_z(rad(1.0)); }
+    #[test] fn test_neg_1()     { check_from_angle_z(rad(-1.0)); }
 }
 
 mod from {
@@ -104,25 +104,25 @@ mod from {
         // triggers: trace >= S::zero()
         #[test]
         fn test_positive_trace() {
-            check_with_euler(rad(0.0f32), rad(0.0), rad(0.0f32));
+            check_with_euler(rad(0.0), rad(0.0), rad(0.0));
         }
 
         // triggers: (mat[0][0] > mat[1][1]) && (mat[0][0] > mat[2][2])
         #[test]
         fn test_xx_maximum() {
-            check_with_euler(rad(2.0f32), rad(1.0), rad(-1.2f32));
+            check_with_euler(rad(2.0), rad(1.0), rad(-1.2));
         }
 
         // triggers: mat[1][1] > mat[2][2]
         #[test]
         fn test_yy_maximum() {
-            check_with_euler(rad(2.0f32), rad(1.0), rad(3.0f32));
+            check_with_euler(rad(2.0), rad(1.0), rad(3.0));
         }
 
         // base case
         #[test]
         fn test_zz_maximum() {
-            check_with_euler(rad(1.0f32), rad(1.0), rad(3.0f32));
+            check_with_euler(rad(1.0), rad(1.0), rad(3.0));
         }
     }
 }

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -45,6 +45,51 @@ mod to_from_euler {
     #[test] fn test_pitch_yaw_roll_neg_hp() { check_euler(rad(0f32), rad(-HPI), rad(1f32)); }
 }
 
+mod from_angle_x {
+    use cgmath::*;
+
+    fn check_from_angle_x(pitch: Rad<f32>) {
+        let found = Quaternion::from_angle_x(pitch);
+        let expected = Quaternion::from_euler(pitch, rad(0.0), rad(0.0));
+
+        assert_approx_eq_eps!(found, expected, 0.001);
+    }
+
+    #[test] fn test_zero()      { check_from_angle_x(rad(0f32)); }
+    #[test] fn test_pos_1()     { check_from_angle_x(rad(1f32)); }
+    #[test] fn test_neg_1()     { check_from_angle_x(rad(-1f32)); }
+}
+
+mod from_angle_y {
+    use cgmath::*;
+
+    fn check_from_angle_y(yaw: Rad<f32>) {
+        let found = Quaternion::from_angle_y(yaw);
+        let expected = Quaternion::from_euler(rad(0.0), yaw, rad(0.0));
+
+        assert_approx_eq_eps!(found, expected, 0.001);
+    }
+
+    #[test] fn test_zero()      { check_from_angle_y(rad(0f32)); }
+    #[test] fn test_pos_1()     { check_from_angle_y(rad(1f32)); }
+    #[test] fn test_neg_1()     { check_from_angle_y(rad(-1f32)); }
+}
+
+mod from_angle_z {
+    use cgmath::*;
+
+    fn check_from_angle_z(roll: Rad<f32>) {
+        let found = Quaternion::from_angle_z(roll);
+        let expected = Quaternion::from_euler(rad(0.0), rad(0.0), roll);
+
+        assert_approx_eq_eps!(found, expected, 0.001);
+    }
+
+    #[test] fn test_zero()      { check_from_angle_z(rad(0f32)); }
+    #[test] fn test_pos_1()     { check_from_angle_z(rad(1f32)); }
+    #[test] fn test_neg_1()     { check_from_angle_z(rad(-1f32)); }
+}
+
 mod from {
     mod matrix3 {
         use cgmath::*;


### PR DESCRIPTION
Fixes #285

- Reorder euler angles in quaternion conversions from `(yaw, pitch, roll)` to
  `(pitch, yaw, roll)` to be consistent with the ordering in matrix conversions.
- Base the `Rotation::from_angle_{x, y, z}` default implementations off
  `Rotation::from_euler` as opposed to `Rotation::from_axis_angle`
- Adds tests for `Quaternion::from_axis_angle`, and fixes the implementation