### PR TITLE
Support for scalar on the lhs of arithmetic operators

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -106,26 +106,14 @@ macro_rules! impl_operator {
                 let ($lhs, $rhs) = (self, other); $body
             }
         }
-    };
-}
 
-macro_rules! impl_scalar_ops {
-    ($VectorN:ident<$S:ident> { $($field:ident),+ }) => {
-        impl_operator!(Add<$VectorN<$S>> for $S {
-            fn add(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar + vector.$field),+) }
-        });
-        impl_operator!(Sub<$VectorN<$S>> for $S {
-            fn sub(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar - vector.$field),+) }
-        });
-        impl_operator!(Mul<$VectorN<$S>> for $S {
-            fn mul(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar * vector.$field),+) }
-        });
-        impl_operator!(Div<$VectorN<$S>> for $S {
-            fn div(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar / vector.$field),+) }
-        });
-        impl_operator!(Rem<$VectorN<$S>> for $S {
-            fn rem(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar % vector.$field),+) }
-        });
+        impl<'a> $Op<&'a $Rhs<$S>> for $Lhs {
+            type Output = $Output;
+            #[inline]
+            fn $op(self, other: &'a $Rhs<$S>) -> $Output {
+                let ($lhs, $rhs) = (self, other); $body
+            }
+        }
     };
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -95,6 +95,38 @@ macro_rules! impl_operator {
             }
         }
     };
+    // When the left operand is a scalar
+    ($Op:ident<$Rhs:ident<$S:ident>> for $Lhs:ty {
+        fn $op:ident($lhs:ident, $rhs:ident) -> $Output:ty { $body:expr }
+    }) => {
+        impl $Op<$Rhs<$S>> for $Lhs {
+            type Output = $Output;
+            #[inline]
+            fn $op(self, other: $Rhs<$S>) -> $Output {
+                let ($lhs, $rhs) = (self, other); $body
+            }
+        }
+    };
+}
+
+macro_rules! impl_scalar_ops {
+    ($VectorN:ident<$S:ident> { $($field:ident),+ }) => {
+        impl_operator!(Add<$VectorN<$S>> for $S {
+            fn add(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar + vector.$field),+) }
+        });
+        impl_operator!(Sub<$VectorN<$S>> for $S {
+            fn sub(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar - vector.$field),+) }
+        });
+        impl_operator!(Mul<$VectorN<$S>> for $S {
+            fn mul(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar * vector.$field),+) }
+        });
+        impl_operator!(Div<$VectorN<$S>> for $S {
+            fn div(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar / vector.$field),+) }
+        });
+        impl_operator!(Rem<$VectorN<$S>> for $S {
+            fn rem(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar % vector.$field),+) }
+        });
+    };
 }
 
 macro_rules! impl_assignment_operator {

--- a/src/point.rs
+++ b/src/point.rs
@@ -172,12 +172,39 @@ macro_rules! impl_point {
             fn rem_assign(&mut self, scalar) { $(self.$field %= scalar);+ }
         });
 
+        impl_scalar_ops!($PointN<usize> { $($field),+ });
+        impl_scalar_ops!($PointN<u8> { $($field),+ });
+        impl_scalar_ops!($PointN<u16> { $($field),+ });
+        impl_scalar_ops!($PointN<u32> { $($field),+ });
+        impl_scalar_ops!($PointN<u64> { $($field),+ });
+        impl_scalar_ops!($PointN<isize> { $($field),+ });
+        impl_scalar_ops!($PointN<i8> { $($field),+ });
+        impl_scalar_ops!($PointN<i16> { $($field),+ });
+        impl_scalar_ops!($PointN<i32> { $($field),+ });
+        impl_scalar_ops!($PointN<i64> { $($field),+ });
+        impl_scalar_ops!($PointN<f32> { $($field),+ });
+        impl_scalar_ops!($PointN<f64> { $($field),+ });
+
         impl_index_operators!($PointN<S>, $n, S, usize);
         impl_index_operators!($PointN<S>, $n, [S], Range<usize>);
         impl_index_operators!($PointN<S>, $n, [S], RangeTo<usize>);
         impl_index_operators!($PointN<S>, $n, [S], RangeFrom<usize>);
         impl_index_operators!($PointN<S>, $n, [S], RangeFull);
     }
+}
+
+macro_rules! impl_scalar_ops {
+    ($PointN:ident<$S:ident> { $($field:ident),+ }) => {
+        impl_operator!(Mul<$PointN<$S>> for $S {
+            fn mul(scalar, vector) -> $PointN<$S> { $PointN::new($(scalar * vector.$field),+) }
+        });
+        impl_operator!(Div<$PointN<$S>> for $S {
+            fn div(scalar, vector) -> $PointN<$S> { $PointN::new($(scalar / vector.$field),+) }
+        });
+        impl_operator!(Rem<$PointN<$S>> for $S {
+            fn rem(scalar, vector) -> $PointN<$S> { $PointN::new($(scalar % vector.$field),+) }
+        });
+    };
 }
 
 impl_point!(Point2 { x, y }, Vector2, 2);

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -167,6 +167,31 @@ impl_operator!(<S: BaseFloat> Mul<Quaternion<S> > for Quaternion<S> {
     }
 });
 
+macro_rules! impl_scalar_mul {
+    ($S:ident) => {
+        impl_operator!(Mul<Quaternion<$S>> for $S {
+            fn mul(scalar, quat) -> Quaternion<$S> {
+                Quaternion::from_sv(scalar * quat.s, scalar * quat.v)
+            }
+        });
+    };
+}
+
+macro_rules! impl_scalar_div {
+    ($S:ident) => {
+        impl_operator!(Div<Quaternion<$S>> for $S {
+            fn div(scalar, quat) -> Quaternion<$S> {
+                Quaternion::from_sv(scalar / quat.s, scalar / quat.v)
+            }
+        });
+    };
+}
+
+impl_scalar_mul!(f32);
+impl_scalar_mul!(f64);
+impl_scalar_div!(f32);
+impl_scalar_div!(f64);
+
 impl<S: BaseFloat> ApproxEq for Quaternion<S> {
     type Epsilon = S;
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -244,6 +244,7 @@ macro_rules! impl_vector {
         impl_operator!(<S: BaseNum> Mul<$VectorN<S> > for $VectorN<S> {
             fn mul(lhs, rhs) -> $VectorN<S> { $VectorN::new($(lhs.$field * rhs.$field),+) }
         });
+
         impl_assignment_operator!(<S: BaseNum> MulAssign<S> for $VectorN<S> {
             fn mul_assign(&mut self, scalar) { $(self.$field *= scalar);+ }
         });
@@ -285,9 +286,19 @@ macro_rules! impl_vector {
     }
 }
 
+macro_rules! impl_vector_scalar_ops {
+    ($($S:ident)*) => ($(
+        impl_scalar_ops!(Vector2<$S> { x, y });
+        impl_scalar_ops!(Vector3<$S> { x, y, z });
+        impl_scalar_ops!(Vector4<$S> { x, y, z, w });
+    )*)
+}
+
 impl_vector!(Vector2<S> { x, y }, 2, vec2);
 impl_vector!(Vector3<S> { x, y, z }, 3, vec3);
 impl_vector!(Vector4<S> { x, y, z, w }, 4, vec4);
+
+impl_vector_scalar_ops!(usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64);
 
 impl_fixed_array_conversions!(Vector2<S> { x: 0, y: 1 }, 2);
 impl_fixed_array_conversions!(Vector3<S> { x: 0, y: 1, z: 2 }, 3);

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -278,6 +278,19 @@ macro_rules! impl_vector {
             fn rem_assign(&mut self, other) { $(self.$field %= other.$field);+ }
         });
 
+        impl_scalar_ops!($VectorN<usize> { $($field),+ });
+        impl_scalar_ops!($VectorN<u8> { $($field),+ });
+        impl_scalar_ops!($VectorN<u16> { $($field),+ });
+        impl_scalar_ops!($VectorN<u32> { $($field),+ });
+        impl_scalar_ops!($VectorN<u64> { $($field),+ });
+        impl_scalar_ops!($VectorN<isize> { $($field),+ });
+        impl_scalar_ops!($VectorN<i8> { $($field),+ });
+        impl_scalar_ops!($VectorN<i16> { $($field),+ });
+        impl_scalar_ops!($VectorN<i32> { $($field),+ });
+        impl_scalar_ops!($VectorN<i64> { $($field),+ });
+        impl_scalar_ops!($VectorN<f32> { $($field),+ });
+        impl_scalar_ops!($VectorN<f64> { $($field),+ });
+
         impl_index_operators!($VectorN<S>, $n, S, usize);
         impl_index_operators!($VectorN<S>, $n, [S], Range<usize>);
         impl_index_operators!($VectorN<S>, $n, [S], RangeTo<usize>);
@@ -286,19 +299,29 @@ macro_rules! impl_vector {
     }
 }
 
-macro_rules! impl_vector_scalar_ops {
-    ($($S:ident)*) => ($(
-        impl_scalar_ops!(Vector2<$S> { x, y });
-        impl_scalar_ops!(Vector3<$S> { x, y, z });
-        impl_scalar_ops!(Vector4<$S> { x, y, z, w });
-    )*)
+macro_rules! impl_scalar_ops {
+    ($VectorN:ident<$S:ident> { $($field:ident),+ }) => {
+        impl_operator!(Add<$VectorN<$S>> for $S {
+            fn add(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar + vector.$field),+) }
+        });
+        impl_operator!(Sub<$VectorN<$S>> for $S {
+            fn sub(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar - vector.$field),+) }
+        });
+        impl_operator!(Mul<$VectorN<$S>> for $S {
+            fn mul(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar * vector.$field),+) }
+        });
+        impl_operator!(Div<$VectorN<$S>> for $S {
+            fn div(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar / vector.$field),+) }
+        });
+        impl_operator!(Rem<$VectorN<$S>> for $S {
+            fn rem(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar % vector.$field),+) }
+        });
+    };
 }
 
 impl_vector!(Vector2<S> { x, y }, 2, vec2);
 impl_vector!(Vector3<S> { x, y, z }, 3, vec3);
 impl_vector!(Vector4<S> { x, y, z, w }, 4, vec4);
-
-impl_vector_scalar_ops!(usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64);
 
 impl_fixed_array_conversions!(Vector2<S> { x: 0, y: 1 }, 2);
 impl_fixed_array_conversions!(Vector3<S> { x: 0, y: 1, z: 2 }, 3);

--- a/tests/point.rs
+++ b/tests/point.rs
@@ -16,11 +16,62 @@
 
 extern crate cgmath;
 
-use cgmath::Point3;
+use cgmath::{Point2, Point3};
 use cgmath::ApproxEq;
+
+macro_rules! impl_test_mul {
+    ($PointN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
+        // point * scalar ops
+        assert_eq!($v * $s, $PointN::new($($v.$field * $s),+));
+        assert_eq!($s * $v, $PointN::new($($s * $v.$field),+));
+        assert_eq!(&$v * $s, $v * $s);
+        assert_eq!($s * &$v, $s * $v);
+        // commutativity
+        assert_eq!($v * $s, $s * $v);
+    )
+}
+
+macro_rules! impl_test_div {
+    ($PointN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
+        // point / scalar ops
+        assert_eq!($v / $s, $PointN::new($($v.$field / $s),+));
+        assert_eq!($s / $v, $PointN::new($($s / $v.$field),+));
+        assert_eq!(&$v / $s, $v / $s);
+        assert_eq!($s / &$v, $s / $v);
+    )
+}
+
+macro_rules! impl_test_rem {
+    ($PointN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
+        // point % scalar ops
+        assert_eq!($v % $s, $PointN::new($($v.$field % $s),+));
+        assert_eq!($s % $v, $PointN::new($($s % $v.$field),+));
+        assert_eq!(&$v % $s, $v % $s);
+        assert_eq!($s % &$v, $s % $v);
+    )
+}
 
 #[test]
 fn test_homogeneous() {
 	let p = Point3::new(1.0f64, 2.0f64, 3.0f64);
     assert!(p.approx_eq(&Point3::from_homogeneous(p.to_homogeneous())));
 }
+
+#[test]
+fn test_mul() {
+    impl_test_mul!(Point3 { x, y, z }, 2.0f32, Point3::new(2.0f32, 4.0, 6.0));
+    impl_test_mul!(Point2 { x, y }, 2.0f32, Point2::new(2.0f32, 4.0));
+}
+
+#[test]
+fn test_div() {
+    impl_test_div!(Point3 { x, y, z }, 2.0f32, Point3::new(2.0f32, 4.0, 6.0));
+    impl_test_div!(Point2 { x, y }, 2.0f32, Point2::new(2.0f32, 4.0));
+}
+
+#[test]
+fn test_rem() {
+    impl_test_rem!(Point3 { x, y, z }, 2.0f32, Point3::new(2.0f32, 4.0, 6.0));
+    impl_test_rem!(Point2 { x, y }, 2.0f32, Point2::new(2.0f32, 4.0));
+}
+

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -16,6 +16,42 @@
 #[macro_use]
 extern crate cgmath;
 
+macro_rules! impl_test_mul {
+    ($s:expr, $v:expr) => (
+        // point * scalar ops
+        assert_eq!($v * $s, Quaternion::from_sv($v.s * $s, $v.v * $s));
+        assert_eq!($s * $v, Quaternion::from_sv($s * $v.s, $s * $v.v));
+        assert_eq!(&$v * $s, $v * $s);
+        assert_eq!($s * &$v, $s * $v);
+        // commutativity
+        assert_eq!($v * $s, $s * $v);
+    )
+}
+
+macro_rules! impl_test_div {
+    ($s:expr, $v:expr) => (
+        // point / scalar ops
+        assert_eq!($v / $s, Quaternion::from_sv($v.s / $s, $v.v / $s));
+        assert_eq!($s / $v, Quaternion::from_sv($s / $v.s, $s / $v.v));
+        assert_eq!(&$v / $s, $v / $s);
+        assert_eq!($s / &$v, $s / $v);
+    )
+}
+
+mod operators {
+    use cgmath::*;
+
+    #[test]
+    fn test_mul() {
+        impl_test_mul!(2.0f32, Quaternion::from_euler(rad(1f32), rad(1f32), rad(1f32)));
+    }
+
+    #[test]
+    fn test_div() {
+        impl_test_div!(2.0f32, Quaternion::from_euler(rad(1f32), rad(1f32), rad(1f32)));
+    }
+}
+
 mod to_from_euler {
     use std::f32;
 

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -33,26 +33,91 @@ fn test_from_value() {
     assert_eq!(Vector4::from_value(76.5f64), Vector4::new(76.5f64, 76.5f64, 76.5f64, 76.5f64));
 }
 
-macro_rules! test_ops {
+macro_rules! test_op_add {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
-        // add
+        // vector + vector ops
+        assert_eq!($v + $v, $VectorN::new($($v.$field + $v.$field),+));
+        assert_eq!(&$v + &$v, $VectorN::new($($v.$field + $v.$field),+));
+        assert_eq!(&$v + $v, $VectorN::new($($v.$field + $v.$field),+));
+        assert_eq!($v + &$v, $VectorN::new($($v.$field + $v.$field),+));
+        // vector + scalar ops
         assert_eq!($v + $s, $VectorN::new($($v.$field + $s),+));
         assert_eq!($s + $v, $VectorN::new($($s + $v.$field),+));
+        assert_eq!(&$v + $s, $VectorN::new($($v.$field + $s),+));
+        assert_eq!($s + &$v, $VectorN::new($($s + $v.$field),+));
         assert_eq!($v + $s, $s + $v);
-        // sub
+    )
+}
+
+macro_rules! test_op_sub {
+    ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
+        // vector - vector ops
+        assert_eq!($v - $v, $VectorN::new($($v.$field - $v.$field),+));
+        assert_eq!(&$v - &$v, $VectorN::new($($v.$field - $v.$field),+));
+        assert_eq!(&$v - $v, $VectorN::new($($v.$field - $v.$field),+));
+        assert_eq!($v - &$v, $VectorN::new($($v.$field - $v.$field),+));
+        // vector - scalar ops
         assert_eq!($v - $s, $VectorN::new($($v.$field - $s),+));
         assert_eq!($s - $v, $VectorN::new($($s - $v.$field),+));
+        assert_eq!(&$v - $s, $VectorN::new($($v.$field - $s),+));
+        assert_eq!($s - &$v, $VectorN::new($($s - $v.$field),+));
         assert_eq!($v - $s, -($s - $v));
-        // mul
+    )
+}
+
+macro_rules! test_op_mul {
+    ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
+        // vector * vector ops
+        assert_eq!($v * $v, $VectorN::new($($v.$field * $v.$field),+));
+        assert_eq!(&$v * &$v, $VectorN::new($($v.$field * $v.$field),+));
+        assert_eq!(&$v * $v, $VectorN::new($($v.$field * $v.$field),+));
+        assert_eq!($v * &$v, $VectorN::new($($v.$field * $v.$field),+));
+        // vector * scalar ops
         assert_eq!($v * $s, $VectorN::new($($v.$field * $s),+));
         assert_eq!($s * $v, $VectorN::new($($s * $v.$field),+));
+        assert_eq!(&$v * $s, $VectorN::new($($v.$field * $s),+));
+        assert_eq!($s * &$v, $VectorN::new($($s * $v.$field),+));
         assert_eq!($v * $s, $s * $v);
-        // div
+    )
+}
+
+macro_rules! test_op_div {
+    ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
+        // vector / vector ops
+        assert_eq!($v / $v, $VectorN::new($($v.$field / $v.$field),+));
+        assert_eq!(&$v / &$v, $VectorN::new($($v.$field / $v.$field),+));
+        assert_eq!(&$v / $v, $VectorN::new($($v.$field / $v.$field),+));
+        assert_eq!($v / &$v, $VectorN::new($($v.$field / $v.$field),+));
+        // vector / scalar ops
         assert_eq!($v / $s, $VectorN::new($($v.$field / $s),+));
         assert_eq!($s / $v, $VectorN::new($($s / $v.$field),+));
-        // rem
+        assert_eq!(&$v / $s, $VectorN::new($($v.$field / $s),+));
+        assert_eq!($s / &$v, $VectorN::new($($s / $v.$field),+));
+    )
+}
+
+macro_rules! test_op_rem {
+    ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
+        // vector % vector ops
+        assert_eq!($v % $v, $VectorN::new($($v.$field % $v.$field),+));
+        assert_eq!(&$v % &$v, $VectorN::new($($v.$field % $v.$field),+));
+        assert_eq!(&$v % $v, $VectorN::new($($v.$field % $v.$field),+));
+        assert_eq!($v % &$v, $VectorN::new($($v.$field % $v.$field),+));
+        // vector % scalar ops
         assert_eq!($v % $s, $VectorN::new($($v.$field % $s),+));
         assert_eq!($s % $v, $VectorN::new($($s % $v.$field),+));
+        assert_eq!(&$v % $s, $VectorN::new($($v.$field % $s),+));
+        assert_eq!($s % &$v, $VectorN::new($($s % $v.$field),+));
+    )
+}
+
+macro_rules! test_ops {
+    ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
+        test_op_add!($VectorN { $($field),+ }, $s, $v);
+        test_op_sub!($VectorN { $($field),+ }, $s, $v);
+        test_op_mul!($VectorN { $($field),+ }, $s, $v);
+        test_op_div!($VectorN { $($field),+ }, $s, $v);
+        test_op_rem!($VectorN { $($field),+ }, $s, $v);
     )
 }
 

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -33,7 +33,7 @@ fn test_from_value() {
     assert_eq!(Vector4::from_value(76.5f64), Vector4::new(76.5f64, 76.5f64, 76.5f64, 76.5f64));
 }
 
-macro_rules! test_op_add {
+macro_rules! impl_test_add {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector + vector ops
         assert_eq!($v + $v, $VectorN::new($($v.$field + $v.$field),+));
@@ -50,7 +50,7 @@ macro_rules! test_op_add {
     )
 }
 
-macro_rules! test_op_sub {
+macro_rules! impl_test_sub {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector - vector ops
         assert_eq!($v - $v, $VectorN::new($($v.$field - $v.$field),+));
@@ -67,7 +67,7 @@ macro_rules! test_op_sub {
     )
 }
 
-macro_rules! test_op_mul {
+macro_rules! impl_test_mul {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector * vector ops
         assert_eq!($v * $v, $VectorN::new($($v.$field * $v.$field),+));
@@ -84,7 +84,7 @@ macro_rules! test_op_mul {
     )
 }
 
-macro_rules! test_op_div {
+macro_rules! impl_test_div {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector / vector ops
         assert_eq!($v / $v, $VectorN::new($($v.$field / $v.$field),+));
@@ -99,7 +99,7 @@ macro_rules! test_op_div {
     )
 }
 
-macro_rules! test_op_rem {
+macro_rules! impl_test_rem {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector % vector ops
         assert_eq!($v % $v, $VectorN::new($($v.$field % $v.$field),+));
@@ -114,29 +114,39 @@ macro_rules! test_op_rem {
     )
 }
 
-macro_rules! test_ops {
-    ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
-        test_op_add!($VectorN { $($field),+ }, $s, $v);
-        test_op_sub!($VectorN { $($field),+ }, $s, $v);
-        test_op_mul!($VectorN { $($field),+ }, $s, $v);
-        test_op_div!($VectorN { $($field),+ }, $s, $v);
-        test_op_rem!($VectorN { $($field),+ }, $s, $v);
-    )
+#[test]
+fn test_add() {
+    impl_test_add!(Vector4 { x, y, z, w }, 2.0f32, vec4(2.0f32, 4.0, 6.0, 8.0));
+    impl_test_add!(Vector3 { x, y, z }, 2.0f32, vec3(2.0f32, 4.0, 6.0));
+    impl_test_add!(Vector2 { x, y }, 2.0f32, vec2(2.0f32, 4.0));
 }
 
 #[test]
-fn test_ops() {
-    let a = [3.0f32, 4.0f32, 5.0f32, 6.0f32];
-    let s = 2.0f32;
+fn test_sub() {
+    impl_test_sub!(Vector4 { x, y, z, w }, 2.0f32, vec4(2.0f32, 4.0, 6.0, 8.0));
+    impl_test_sub!(Vector3 { x, y, z }, 2.0f32, vec3(2.0f32, 4.0, 6.0));
+    impl_test_sub!(Vector2 { x, y }, 2.0f32, vec2(2.0f32, 4.0));
+}
 
-    let v4 = Vector4::from(a);
-    test_ops!(Vector4 { x, y, z, w }, s, v4);
+#[test]
+fn test_mul() {
+    impl_test_mul!(Vector4 { x, y, z, w }, 2.0f32, vec4(2.0f32, 4.0, 6.0, 8.0));
+    impl_test_mul!(Vector3 { x, y, z }, 2.0f32, vec3(2.0f32, 4.0, 6.0));
+    impl_test_mul!(Vector2 { x, y }, 2.0f32, vec2(2.0f32, 4.0));
+}
 
-    let v3 = v4.truncate();
-    test_ops!(Vector3 { x, y, z }, s, v3);
+#[test]
+fn test_div() {
+    impl_test_div!(Vector4 { x, y, z, w }, 2.0f32, vec4(2.0f32, 4.0, 6.0, 8.0));
+    impl_test_div!(Vector3 { x, y, z }, 2.0f32, vec3(2.0f32, 4.0, 6.0));
+    impl_test_div!(Vector2 { x, y }, 2.0f32, vec2(2.0f32, 4.0));
+}
 
-    let v2 = v3.truncate();
-    test_ops!(Vector2 { x, y }, s, v2);
+#[test]
+fn test_rem() {
+    impl_test_rem!(Vector4 { x, y, z, w }, 2.0f32, vec4(2.0f32, 4.0, 6.0, 8.0));
+    impl_test_rem!(Vector3 { x, y, z }, 2.0f32, vec3(2.0f32, 4.0, 6.0));
+    impl_test_rem!(Vector2 { x, y }, 2.0f32, vec2(2.0f32, 4.0));
 }
 
 #[test]

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -37,14 +37,15 @@ macro_rules! test_op_add {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector + vector ops
         assert_eq!($v + $v, $VectorN::new($($v.$field + $v.$field),+));
-        assert_eq!(&$v + &$v, $VectorN::new($($v.$field + $v.$field),+));
-        assert_eq!(&$v + $v, $VectorN::new($($v.$field + $v.$field),+));
-        assert_eq!($v + &$v, $VectorN::new($($v.$field + $v.$field),+));
+        assert_eq!(&$v + &$v, $v + $v);
+        assert_eq!(&$v + $v, $v + $v);
+        assert_eq!($v + &$v, $v + $v);
         // vector + scalar ops
         assert_eq!($v + $s, $VectorN::new($($v.$field + $s),+));
         assert_eq!($s + $v, $VectorN::new($($s + $v.$field),+));
-        assert_eq!(&$v + $s, $VectorN::new($($v.$field + $s),+));
-        assert_eq!($s + &$v, $VectorN::new($($s + $v.$field),+));
+        assert_eq!(&$v + $s, $v + $s);
+        assert_eq!($s + &$v, $s + $v);
+        // commutativity
         assert_eq!($v + $s, $s + $v);
     )
 }
@@ -53,14 +54,15 @@ macro_rules! test_op_sub {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector - vector ops
         assert_eq!($v - $v, $VectorN::new($($v.$field - $v.$field),+));
-        assert_eq!(&$v - &$v, $VectorN::new($($v.$field - $v.$field),+));
-        assert_eq!(&$v - $v, $VectorN::new($($v.$field - $v.$field),+));
-        assert_eq!($v - &$v, $VectorN::new($($v.$field - $v.$field),+));
+        assert_eq!(&$v - &$v, $v - $v);
+        assert_eq!(&$v - $v, $v - $v);
+        assert_eq!($v - &$v, $v - $v);
         // vector - scalar ops
         assert_eq!($v - $s, $VectorN::new($($v.$field - $s),+));
         assert_eq!($s - $v, $VectorN::new($($s - $v.$field),+));
-        assert_eq!(&$v - $s, $VectorN::new($($v.$field - $s),+));
-        assert_eq!($s - &$v, $VectorN::new($($s - $v.$field),+));
+        assert_eq!(&$v - $s, $v - $s);
+        assert_eq!($s - &$v, $s - $v);
+        // commutativity
         assert_eq!($v - $s, -($s - $v));
     )
 }
@@ -69,14 +71,15 @@ macro_rules! test_op_mul {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector * vector ops
         assert_eq!($v * $v, $VectorN::new($($v.$field * $v.$field),+));
-        assert_eq!(&$v * &$v, $VectorN::new($($v.$field * $v.$field),+));
-        assert_eq!(&$v * $v, $VectorN::new($($v.$field * $v.$field),+));
-        assert_eq!($v * &$v, $VectorN::new($($v.$field * $v.$field),+));
+        assert_eq!(&$v * &$v, $v * $v);
+        assert_eq!(&$v * $v, $v * $v);
+        assert_eq!($v * &$v, $v * $v);
         // vector * scalar ops
         assert_eq!($v * $s, $VectorN::new($($v.$field * $s),+));
         assert_eq!($s * $v, $VectorN::new($($s * $v.$field),+));
-        assert_eq!(&$v * $s, $VectorN::new($($v.$field * $s),+));
-        assert_eq!($s * &$v, $VectorN::new($($s * $v.$field),+));
+        assert_eq!(&$v * $s, $v * $s);
+        assert_eq!($s * &$v, $s * $v);
+        // commutativity
         assert_eq!($v * $s, $s * $v);
     )
 }
@@ -85,14 +88,14 @@ macro_rules! test_op_div {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector / vector ops
         assert_eq!($v / $v, $VectorN::new($($v.$field / $v.$field),+));
-        assert_eq!(&$v / &$v, $VectorN::new($($v.$field / $v.$field),+));
-        assert_eq!(&$v / $v, $VectorN::new($($v.$field / $v.$field),+));
-        assert_eq!($v / &$v, $VectorN::new($($v.$field / $v.$field),+));
+        assert_eq!(&$v / &$v, $v / $v);
+        assert_eq!(&$v / $v, $v / $v);
+        assert_eq!($v / &$v, $v / $v);
         // vector / scalar ops
         assert_eq!($v / $s, $VectorN::new($($v.$field / $s),+));
         assert_eq!($s / $v, $VectorN::new($($s / $v.$field),+));
-        assert_eq!(&$v / $s, $VectorN::new($($v.$field / $s),+));
-        assert_eq!($s / &$v, $VectorN::new($($s / $v.$field),+));
+        assert_eq!(&$v / $s, $v / $s);
+        assert_eq!($s / &$v, $s / $v);
     )
 }
 
@@ -100,14 +103,14 @@ macro_rules! test_op_rem {
     ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
         // vector % vector ops
         assert_eq!($v % $v, $VectorN::new($($v.$field % $v.$field),+));
-        assert_eq!(&$v % &$v, $VectorN::new($($v.$field % $v.$field),+));
-        assert_eq!(&$v % $v, $VectorN::new($($v.$field % $v.$field),+));
-        assert_eq!($v % &$v, $VectorN::new($($v.$field % $v.$field),+));
+        assert_eq!(&$v % &$v, $v % $v);
+        assert_eq!(&$v % $v, $v % $v);
+        assert_eq!($v % &$v, $v % $v);
         // vector % scalar ops
         assert_eq!($v % $s, $VectorN::new($($v.$field % $s),+));
         assert_eq!($s % $v, $VectorN::new($($s % $v.$field),+));
-        assert_eq!(&$v % $s, $VectorN::new($($v.$field % $s),+));
-        assert_eq!($s % &$v, $VectorN::new($($s % $v.$field),+));
+        assert_eq!(&$v % $s, $v % $s);
+        assert_eq!($s % &$v, $s % $v);
     )
 }
 

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -33,6 +33,44 @@ fn test_from_value() {
     assert_eq!(Vector4::from_value(76.5f64), Vector4::new(76.5f64, 76.5f64, 76.5f64, 76.5f64));
 }
 
+macro_rules! test_ops {
+    ($VectorN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (
+        // add
+        assert_eq!($v + $s, $VectorN::new($($v.$field + $s),+));
+        assert_eq!($s + $v, $VectorN::new($($s + $v.$field),+));
+        assert_eq!($v + $s, $s + $v);
+        // sub
+        assert_eq!($v - $s, $VectorN::new($($v.$field - $s),+));
+        assert_eq!($s - $v, $VectorN::new($($s - $v.$field),+));
+        assert_eq!($v - $s, -($s - $v));
+        // mul
+        assert_eq!($v * $s, $VectorN::new($($v.$field * $s),+));
+        assert_eq!($s * $v, $VectorN::new($($s * $v.$field),+));
+        assert_eq!($v * $s, $s * $v);
+        // div
+        assert_eq!($v / $s, $VectorN::new($($v.$field / $s),+));
+        assert_eq!($s / $v, $VectorN::new($($s / $v.$field),+));
+        // rem
+        assert_eq!($v % $s, $VectorN::new($($v.$field % $s),+));
+        assert_eq!($s % $v, $VectorN::new($($s % $v.$field),+));
+    )
+}
+
+#[test]
+fn test_ops() {
+    let a = [3.0f32, 4.0f32, 5.0f32, 6.0f32];
+    let s = 2.0f32;
+
+    let v4 = Vector4::from(a);
+    test_ops!(Vector4 { x, y, z, w }, s, v4);
+
+    let v3 = v4.truncate();
+    test_ops!(Vector3 { x, y, z }, s, v3);
+
+    let v2 = v3.truncate();
+    test_ops!(Vector2 { x, y }, s, v2);
+}
+
 #[test]
 fn test_dot() {
     assert_eq!(Vector2::new(1isize, 2isize).dot(Vector2::new(3isize, 4isize)), 11isize);


### PR DESCRIPTION
This change adds support for scalars on the left hand side of arithmetic operators, so far just for VectorN types.

In cgmath you could write code like ```Vector3::unit_y() * 2.0``` but not ```2.0 * Vector3::unit_y()```. This change adds support for the latter.

To do this, I had to add trait support for each built in numeric type. I've done this using macros, trying to keep the style close to what was already there. I noticed for the Vector operators there are also operators that take a reference, I'm not sure if I need to provide those or not?

I've also added a few tests for operators. I've used a macro to cut down on duplicate code, the down side being when it fails it's a pain to work out which line failed.


