### PR TITLE
Small doc fix for EuclideanVector trait

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -448,7 +448,7 @@ impl<S: BaseNum> Vector4<S> {
 }
 
 /// Specifies geometric operations for vectors. This is only implemented for
-/// 2-dimensional and 3-dimensional vectors.
+/// vectors of float types.
 pub trait EuclideanVector: Vector + Sized where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     <Self as Vector>::Scalar: BaseFloat,


### PR DESCRIPTION
Docs state EuclideanVector trait is only implemented for 2d and 3d vectors, but there does appear to be a Vector4 implementation. 

Added that it's only implemented for float types, since I didn't realise that initially.