### PR TITLE
Remove now default 'sudo: false'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: rust
 
 rust:


### PR DESCRIPTION
'sudo: false' is now default on Travis CI.