### PR TITLE
Stabilise assignment operators

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -78,9 +78,9 @@ pub trait ElementWise<Rhs = Self> {
     fn div_element_wise(self, rhs: Rhs) -> Self;
     fn rem_element_wise(self, rhs: Rhs) -> Self;
 
-    #[cfg(feature = "unstable")] fn add_assign_element_wise(&mut self, rhs: Rhs);
-    #[cfg(feature = "unstable")] fn sub_assign_element_wise(&mut self, rhs: Rhs);
-    #[cfg(feature = "unstable")] fn mul_assign_element_wise(&mut self, rhs: Rhs);
-    #[cfg(feature = "unstable")] fn div_assign_element_wise(&mut self, rhs: Rhs);
-    #[cfg(feature = "unstable")] fn rem_assign_element_wise(&mut self, rhs: Rhs);
+    fn add_assign_element_wise(&mut self, rhs: Rhs);
+    fn sub_assign_element_wise(&mut self, rhs: Rhs);
+    fn mul_assign_element_wise(&mut self, rhs: Rhs);
+    fn div_assign_element_wise(&mut self, rhs: Rhs);
+    fn rem_assign_element_wise(&mut self, rhs: Rhs);
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -121,7 +121,6 @@ macro_rules! impl_assignment_operator {
     (<$S:ident: $Constraint:ident> $Op:ident<$Rhs:ty> for $Lhs:ty {
         fn $op:ident(&mut $lhs:ident, $rhs:ident) $body:block
     }) => {
-        #[cfg(feature = "unstable")]
         impl<$S: $Constraint + $Op<$S>> $Op<$Rhs> for $Lhs {
             #[inline]
             fn $op(&mut $lhs, $rhs: $Rhs) $body

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -865,11 +865,9 @@ macro_rules! impl_operators {
         impl_operator!(<S: BaseFloat> Sub<$MatrixN<S> > for $MatrixN<S> {
             fn sub(lhs, rhs) -> $MatrixN<S> { $MatrixN { $($field: lhs.$field - rhs.$field),+ } }
         });
-        #[cfg(feature = "unstable")]
         impl<S: BaseFloat + AddAssign<S>> AddAssign<$MatrixN<S>> for $MatrixN<S> {
             fn add_assign(&mut self, other: $MatrixN<S>) { $(self.$field += other.$field);+ }
         }
-        #[cfg(feature = "unstable")]
         impl<S: BaseFloat + SubAssign<S>> SubAssign<$MatrixN<S>> for $MatrixN<S> {
             fn sub_assign(&mut self, other: $MatrixN<S>) { $(self.$field -= other.$field);+ }
         }

--- a/src/num.rs
+++ b/src/num.rs
@@ -17,7 +17,6 @@ use approx::ApproxEq;
 
 use std::cmp;
 use std::fmt;
-#[cfg(feature = "unstable")]
 use std::ops::*;
 
 use rust_num::{Float, Num, NumCast};
@@ -62,16 +61,6 @@ partial_ord_float!(f64);
 
 
 /// Base numeric types with partial ordering
-#[cfg(not(feature = "unstable"))]
-pub trait BaseNum where
-    Self: Copy + Clone + fmt::Debug,
-    Self: Num + NumCast,
-    Self: PartialOrd + cmp::PartialOrd,
-{}
-
-
-/// Base numeric types with partial ordering
-#[cfg(feature = "unstable")]
 pub trait BaseNum where
     Self: Copy + Clone + fmt::Debug,
     Self: Num + NumCast,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -267,11 +267,11 @@ macro_rules! impl_vector {
             #[inline] fn div_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field / rhs.$field),+) }
             #[inline] fn rem_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field % rhs.$field),+) }
 
-            #[cfg(feature = "unstable")] #[inline] fn add_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field += rhs.$field);+ }
-            #[cfg(feature = "unstable")] #[inline] fn sub_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field -= rhs.$field);+ }
-            #[cfg(feature = "unstable")] #[inline] fn mul_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field *= rhs.$field);+ }
-            #[cfg(feature = "unstable")] #[inline] fn div_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field /= rhs.$field);+ }
-            #[cfg(feature = "unstable")] #[inline] fn rem_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field %= rhs.$field);+ }
+            #[inline] fn add_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field += rhs.$field);+ }
+            #[inline] fn sub_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field -= rhs.$field);+ }
+            #[inline] fn mul_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field *= rhs.$field);+ }
+            #[inline] fn div_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field /= rhs.$field);+ }
+            #[inline] fn rem_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field %= rhs.$field);+ }
         }
 
         impl<S: BaseNum> ElementWise<S> for $VectorN<S> {
@@ -281,11 +281,11 @@ macro_rules! impl_vector {
             #[inline] fn div_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field / rhs),+) }
             #[inline] fn rem_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field % rhs),+) }
 
-            #[cfg(feature = "unstable")] #[inline] fn add_assign_element_wise(&mut self, rhs: S) { $(self.$field += rhs);+ }
-            #[cfg(feature = "unstable")] #[inline] fn sub_assign_element_wise(&mut self, rhs: S) { $(self.$field -= rhs);+ }
-            #[cfg(feature = "unstable")] #[inline] fn mul_assign_element_wise(&mut self, rhs: S) { $(self.$field *= rhs);+ }
-            #[cfg(feature = "unstable")] #[inline] fn div_assign_element_wise(&mut self, rhs: S) { $(self.$field /= rhs);+ }
-            #[cfg(feature = "unstable")] #[inline] fn rem_assign_element_wise(&mut self, rhs: S) { $(self.$field %= rhs);+ }
+            #[inline] fn add_assign_element_wise(&mut self, rhs: S) { $(self.$field += rhs);+ }
+            #[inline] fn sub_assign_element_wise(&mut self, rhs: S) { $(self.$field -= rhs);+ }
+            #[inline] fn mul_assign_element_wise(&mut self, rhs: S) { $(self.$field *= rhs);+ }
+            #[inline] fn div_assign_element_wise(&mut self, rhs: S) { $(self.$field /= rhs);+ }
+            #[inline] fn rem_assign_element_wise(&mut self, rhs: S) { $(self.$field %= rhs);+ }
         }
 
         impl_scalar_ops!($VectorN<usize> { $($field),+ });


### PR DESCRIPTION
Assignment operators were stabilised in Rust 1.8.