### PR TITLE
Re-export num-traits crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! use cgmath::prelude::*;
 //! ```
 
-extern crate num_traits;
+extern crate num_traits as _num_traits;
 extern crate rustc_serialize;
 extern crate rand;
 
@@ -75,6 +75,7 @@ pub use num_traits::{One, Zero};
 // Modules
 
 pub mod conv;
+pub use _num_traits as num_traits;
 pub mod prelude;
 
 mod macros;


### PR DESCRIPTION
I'm not sure whether we should continue to depend on the `num_traits` crate, but at least this makes it easier for clients of cgmath to access the traits from the crate, rather than having to add `num_traits` to their own `Cargo.toml`.