### PR TITLE
implement Transform for Matrix3 and Matrix4

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -756,6 +756,33 @@ impl<S: BaseFloat> ApproxEq for Matrix4<S> {
     }
 }
 
+impl<S: BaseFloat> Transform<Point3<S>> for Matrix3<S> {
+  fn one() -> Matrix3<S> {
+    One::one()
+  }
+
+  fn look_at(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Matrix3<S> {
+    let dir = center - eye;
+    Matrix3::look_at(dir, up)
+  }
+
+  fn transform_vector(&self, vec: Vector3<S>) -> Vector3<S> {
+    self * vec
+  }
+
+  fn transform_point(&self, point: Point3<S>) -> Point3<S> {
+    Point3::from_vec(self * point.to_vec())
+  }
+
+  fn concat(&self, other: &Matrix3<S>) -> Matrix3<S> {
+    self * other
+  }
+
+  fn invert(&self) -> Option<Matrix3<S>> {
+    SquareMatrix::invert(self)
+  }
+}
+
 impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
   fn one() -> Matrix4<S> {
     One::one()
@@ -781,6 +808,8 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
     SquareMatrix::invert(self)
   }
 }
+
+impl<S: BaseFloat> Transform3<S> for Matrix3<S> {}
 
 impl<S: BaseFloat> Transform3<S> for Matrix4<S> {}
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -778,7 +778,7 @@ impl<S: BaseFloat> Transform<Point2<S>> for Matrix3<S> {
     self * other
   }
 
-  fn invert(&self) -> Option<Matrix3<S>> {
+  fn inverse_transform(&self) -> Option<Matrix3<S>> {
     SquareMatrix::invert(self)
   }
 }
@@ -805,7 +805,7 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix3<S> {
     self * other
   }
 
-  fn invert(&self) -> Option<Matrix3<S>> {
+  fn inverse_transform(&self) -> Option<Matrix3<S>> {
     SquareMatrix::invert(self)
   }
 }
@@ -831,7 +831,7 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
     self * other
   }
 
-  fn invert(&self) -> Option<Matrix4<S>> {
+  fn inverse_transform(&self) -> Option<Matrix4<S>> {
     SquareMatrix::invert(self)
   }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -178,37 +178,6 @@ impl<S: BaseFloat> Matrix3<S> {
     }
 }
 
-impl<A> From<Euler<A>> for Matrix3<<A as Angle>::Unitless> where
-    A: Angle + Into<Rad<<A as Angle>::Unitless>>,
-{
-    fn from(src: Euler<A>) -> Matrix3<A::Unitless> {
-        // http://en.wikipedia.org/wiki/Rotation_matrix#General_rotations
-        let (sx, cx) = Rad::sin_cos(src.x.into());
-        let (sy, cy) = Rad::sin_cos(src.y.into());
-        let (sz, cz) = Rad::sin_cos(src.z.into());
-
-        Matrix3::new(cy * cz, cy * sz, -sy,
-                     -cx * sz + sx * sy * cz, cx * cz + sx * sy * sz, sx * cy,
-                     sx * sz + cx * sy * cz, -sx * cz + cx * sy * sz, cx * cy)
-    }
-}
-
-impl<A> From<Euler<A>> for Matrix4<<A as Angle>::Unitless> where
-    A: Angle + Into<Rad<<A as Angle>::Unitless>>,
-{
-    fn from(src: Euler<A>) -> Matrix4<A::Unitless> {
-        // http://en.wikipedia.org/wiki/Rotation_matrix#General_rotations
-        let (sx, cx) = Rad::sin_cos(src.x.into());
-        let (sy, cy) = Rad::sin_cos(src.y.into());
-        let (sz, cz) = Rad::sin_cos(src.z.into());
-
-        Matrix4::new(cy * cz, cy * sz, -sy, A::Unitless::zero(),
-                     -cx * sz + sx * sy * cz, cx * cz + sx * sy * sz, sx * cy, A::Unitless::zero(),
-                     sx * sz + cx * sy * cz, -sx * cz + cx * sy * sz, cx * cy, A::Unitless::zero(),
-                     A::Unitless::zero(), A::Unitless::zero(), A::Unitless::zero(), A::Unitless::one())
-    }
-}
-
 impl<S: BaseFloat> Matrix4<S> {
     /// Create a new matrix, providing values for each index.
     #[inline]
@@ -935,6 +904,37 @@ index_operators!(Matrix4<S>, 4, Vector4<S>, usize);
 // index_operators!(Matrix2<S>, 2, [Vector2<S>], RangeFull);
 // index_operators!(Matrix3<S>, 3, [Vector3<S>], RangeFull);
 // index_operators!(Matrix4<S>, 4, [Vector4<S>], RangeFull);
+
+impl<A> From<Euler<A>> for Matrix3<<A as Angle>::Unitless> where
+    A: Angle + Into<Rad<<A as Angle>::Unitless>>,
+{
+    fn from(src: Euler<A>) -> Matrix3<A::Unitless> {
+        // http://en.wikipedia.org/wiki/Rotation_matrix#General_rotations
+        let (sx, cx) = Rad::sin_cos(src.x.into());
+        let (sy, cy) = Rad::sin_cos(src.y.into());
+        let (sz, cz) = Rad::sin_cos(src.z.into());
+
+        Matrix3::new(cy * cz, cy * sz, -sy,
+                     -cx * sz + sx * sy * cz, cx * cz + sx * sy * sz, sx * cy,
+                     sx * sz + cx * sy * cz, -sx * cz + cx * sy * sz, cx * cy)
+    }
+}
+
+impl<A> From<Euler<A>> for Matrix4<<A as Angle>::Unitless> where
+    A: Angle + Into<Rad<<A as Angle>::Unitless>>,
+{
+    fn from(src: Euler<A>) -> Matrix4<A::Unitless> {
+        // http://en.wikipedia.org/wiki/Rotation_matrix#General_rotations
+        let (sx, cx) = Rad::sin_cos(src.x.into());
+        let (sy, cy) = Rad::sin_cos(src.y.into());
+        let (sz, cz) = Rad::sin_cos(src.z.into());
+
+        Matrix4::new(cy * cz, cy * sz, -sy, A::Unitless::zero(),
+                     -cx * sz + sx * sy * cz, cx * cz + sx * sy * sz, sx * cy, A::Unitless::zero(),
+                     sx * sz + cx * sy * cz, -sx * cz + cx * sy * sz, cx * cy, A::Unitless::zero(),
+                     A::Unitless::zero(), A::Unitless::zero(), A::Unitless::zero(), A::Unitless::one())
+    }
+}
 
 macro_rules! fixed_array_conversions {
     ($MatrixN:ident <$S:ident> { $($field:ident : $index:expr),+ }, $n:expr) => {

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -26,7 +26,7 @@ use angle::Rad;
 use approx::ApproxEq;
 use euler::Euler;
 use num::BaseFloat;
-use point::Point3;
+use point::{Point2, Point3};
 use quaternion::Quaternion;
 use transform::{Transform, Transform2, Transform3};
 use vector::{Vector2, Vector3, Vector4};
@@ -756,6 +756,33 @@ impl<S: BaseFloat> ApproxEq for Matrix4<S> {
     }
 }
 
+impl<S: BaseFloat> Transform<Point2<S>> for Matrix3<S> {
+  fn one() -> Matrix3<S> {
+    One::one()
+  }
+
+  fn look_at(eye: Point2<S>, center: Point2<S>, up: Vector2<S>) -> Matrix3<S> {
+    let dir = center - eye;
+    Matrix3::from(Matrix2::look_at(dir, up))
+  }
+
+  fn transform_vector(&self, vec: Vector2<S>) -> Vector2<S> {
+    (self * vec.extend(S::zero())).truncate()
+  }
+
+  fn transform_point(&self, point: Point2<S>) -> Point2<S> {
+    Point2::from_vec((self * Point3::new(point.x, point.y, S::one()).to_vec()).truncate())
+  }
+
+  fn concat(&self, other: &Matrix3<S>) -> Matrix3<S> {
+    self * other
+  }
+
+  fn invert(&self) -> Option<Matrix3<S>> {
+    SquareMatrix::invert(self)
+  }
+}
+
 impl<S: BaseFloat> Transform<Point3<S>> for Matrix3<S> {
   fn one() -> Matrix3<S> {
     One::one()
@@ -808,6 +835,8 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
     SquareMatrix::invert(self)
   }
 }
+
+impl<S: BaseFloat> Transform2<S> for Matrix3<S> {}
 
 impl<S: BaseFloat> Transform3<S> for Matrix3<S> {}
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -28,6 +28,7 @@ use euler::Euler;
 use num::BaseFloat;
 use point::Point3;
 use quaternion::Quaternion;
+use transform::{Transform, Transform2, Transform3};
 use vector::{Vector2, Vector3, Vector4};
 
 /// A 2 x 2, column major matrix
@@ -754,6 +755,34 @@ impl<S: BaseFloat> ApproxEq for Matrix4<S> {
         self[3].approx_eq_eps(&other[3], epsilon)
     }
 }
+
+impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
+  fn one() -> Matrix4<S> {
+    One::one()
+  }
+
+  fn look_at(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Matrix4<S> {
+    Matrix4::look_at(eye, center, up)
+  }
+
+  fn transform_vector(&self, vec: Vector3<S>) -> Vector3<S> {
+    (self * vec.extend(S::zero())).truncate()
+  }
+
+  fn transform_point(&self, point: Point3<S>) -> Point3<S> {
+    Point3::from_homogeneous(self * point.to_homogeneous())
+  }
+
+  fn concat(&self, other: &Matrix4<S>) -> Matrix4<S> {
+    self * other
+  }
+
+  fn invert(&self) -> Option<Matrix4<S>> {
+    SquareMatrix::invert(self)
+  }
+}
+
+impl<S: BaseFloat> Transform3<S> for Matrix4<S> {}
 
 macro_rules! impl_operators {
     ($MatrixN:ident, $VectorN:ident { $($field:ident : $row_index:expr),+ }) => {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -197,7 +197,7 @@ impl<S: BaseFloat> Transform<Point3<S>> for AffineMatrix3<S> {
 
     #[inline]
     fn invert(&self) -> Option<AffineMatrix3<S>> {
-        self.mat.invert().map(|m| AffineMatrix3{ mat: m })
+        SquareMatrix::invert(& self.mat).map(|m| AffineMatrix3{ mat: m })
     }
 }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -53,7 +53,7 @@ pub trait Transform<P: EuclideanSpace>: Sized {
     fn concat(&self, other: &Self) -> Self;
 
     /// Create a transform that "un-does" this one.
-    fn invert(&self) -> Option<Self>;
+    fn inverse_transform(&self) -> Option<Self>;
 
     /// Combine this transform with another, in-place.
     #[inline]
@@ -64,8 +64,8 @@ pub trait Transform<P: EuclideanSpace>: Sized {
     /// Invert this transform in-place, failing if the transformation is not
     /// invertible.
     #[inline]
-    fn invert_self(&mut self) {
-        *self = self.invert().unwrap()
+    fn to_inverse(&mut self) {
+        *self = self.inverse_transform().unwrap()
     }
 }
 
@@ -122,7 +122,7 @@ impl<P: EuclideanSpace, R: Rotation<P>> Transform<P> for Decomposed<P::Diff, R> 
         }
     }
 
-    fn invert(&self) -> Option<Decomposed<P::Diff, R>> {
+    fn inverse_transform(&self) -> Option<Decomposed<P::Diff, R>> {
         if self.scale.approx_eq(&P::Scalar::zero()) {
             None
         } else {
@@ -196,7 +196,7 @@ impl<S: BaseFloat> Transform<Point3<S>> for AffineMatrix3<S> {
     }
 
     #[inline]
-    fn invert(&self) -> Option<AffineMatrix3<S>> {
+    fn inverse_transform(&self) -> Option<AffineMatrix3<S>> {
         SquareMatrix::invert(& self.mat).map(|m| AffineMatrix3{ mat: m })
     }
 }

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -26,7 +26,7 @@ fn test_invert() {
         rot: Quaternion::new(0.5f64,0.5,0.5,0.5),
         disp: Vector3::new(6.0f64,-7.0,8.0)
     };
-	let ti = t.invert().expect("Expected successful inversion");
+	let ti = t.inverse_transform().expect("Expected successful inversion");
 	let vt = t.transform_vector(v);
     assert!(v.approx_eq(&ti.transform_vector(vt)));
 }


### PR DESCRIPTION
Pursuant to conversations in #337, #302, and #324, I've implemented Transform for these two matrices. This makes working with the matrices as fully-fledged transformations much easier.

Along the lines of https://github.com/bjz/cgmath/pull/302#issuecomment-211168768, I've also implemented Transform2 and Transform3 for Matrix3, to reflect its potential use as both a 3D rotation matrix and a 2D affine transform.

Transform3 is implemented for Matrix4 as well, and I moved the From<Euler> impls down with the rest of the From impls, in an unrelated edit which I think nonetheless improves readability of what is now a rather large file.

I'm not positive I've gotten the Transform2 implementation for Matrix3 correct, would appreciate a sanity check :D