### PR TITLE
Rotation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Fix quaternion to Euler angles and Euler angles to quaternion conversion. The axes are now
+  correct, and the order the angles are applied is XYZ.
+
 ## [v0.9.1] - 2016-04-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Fix quaternion to Euler angles and Euler angles to quaternion conversion. The axes are now
-  correct, and the order the angles are applied is XYZ.
+- Fix Euler angles to quaternion and quaternion to Euler angles conversion. The axes are now
+  correct, and the order the angles are applied is XYZ. The conversion now matches the conversion
+  from axis angle.
+- Fix Euler angles to matrix conversion.
 
 ## [v0.9.1] - 2016-04-20
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -161,6 +161,8 @@ impl<S: BaseFloat> Matrix3<S> {
     }
 
     /// Create a rotation matrix from an angle around an arbitrary axis.
+    ///
+    /// The specified axis **must be normalized**, or it represents an invalid rotation.
     pub fn from_axis_angle(axis: Vector3<S>, angle: Rad<S>) -> Matrix3<S> {
         let (s, c) = Rad::sin_cos(angle);
         let _1subc = S::one() - c;
@@ -266,6 +268,8 @@ impl<S: BaseFloat> Matrix4<S> {
     }
 
     /// Create a homogeneous transformation matrix from an angle around an arbitrary axis.
+    ///
+    /// The specified axis **must be normalized**, or it represents an invalid rotation.
     pub fn from_axis_angle(axis: Vector3<S>, angle: Rad<S>) -> Matrix4<S> {
         let (s, c) = Rad::sin_cos(angle);
         let _1subc = S::one() - c;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1000,14 +1000,14 @@ impl<A> From<Euler<A>> for Matrix3<<A as Angle>::Unitless> where
     A: Angle + Into<Rad<<A as Angle>::Unitless>>,
 {
     fn from(src: Euler<A>) -> Matrix3<A::Unitless> {
-        // http://en.wikipedia.org/wiki/Rotation_matrix#General_rotations
+        // Page A-2: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf
         let (sx, cx) = Rad::sin_cos(src.x.into());
         let (sy, cy) = Rad::sin_cos(src.y.into());
         let (sz, cz) = Rad::sin_cos(src.z.into());
 
-        Matrix3::new(cy * cz, cy * sz, -sy,
-                     -cx * sz + sx * sy * cz, cx * cz + sx * sy * sz, sx * cy,
-                     sx * sz + cx * sy * cz, -sx * cz + cx * sy * sz, cx * cy)
+        Matrix3::new(cy * cz, cx * sz + sx * sy * cz, sx * sz - cx * sy * cz,
+                     -cy * sz, cx * cz - sx * sy * sz, sx * cz + cx * sy * sz,
+                     sy, -sx * cy, cx * cy)
     }
 }
 
@@ -1015,14 +1015,14 @@ impl<A> From<Euler<A>> for Matrix4<<A as Angle>::Unitless> where
     A: Angle + Into<Rad<<A as Angle>::Unitless>>,
 {
     fn from(src: Euler<A>) -> Matrix4<A::Unitless> {
-        // http://en.wikipedia.org/wiki/Rotation_matrix#General_rotations
+        // Page A-2: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf
         let (sx, cx) = Rad::sin_cos(src.x.into());
         let (sy, cy) = Rad::sin_cos(src.y.into());
         let (sz, cz) = Rad::sin_cos(src.z.into());
 
-        Matrix4::new(cy * cz, cy * sz, -sy, A::Unitless::zero(),
-                     -cx * sz + sx * sy * cz, cx * cz + sx * sy * sz, sx * cy, A::Unitless::zero(),
-                     sx * sz + cx * sy * cz, -sx * cz + cx * sy * sz, cx * cy, A::Unitless::zero(),
+        Matrix4::new(cy * cz, cx * sz + sx * sy * cz, sx * sz - cx * sy * cz, A::Unitless::zero(),
+                     -cy * sz, cx * cz - sx * sy * sz, sx * cz + cx * sy * sz, A::Unitless::zero(),
+                     sy, -sx * cy, cx * cy, A::Unitless::zero(),
                      A::Unitless::zero(), A::Unitless::zero(), A::Unitless::zero(), A::Unitless::one())
     }
 }

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -156,17 +156,20 @@ impl<A> From<Euler<A>> for Quaternion<<A as Angle>::Unitless> where
     A: Angle + Into<Rad<<A as Angle>::Unitless>>,
 {
     fn from(src: Euler<A>) -> Quaternion<A::Unitless> {
+        // Euclidean Space has an Euler to quat equation, but it is for a different order (YXZ):
         // http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/index.htm
+        // Page A-2 here has the formula for XYZ:
+        // http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf
 
         let half = cast(0.5f64).unwrap();
         let (s_x, c_x) = Rad::sin_cos(src.x.into() * half);
         let (s_y, c_y) = Rad::sin_cos(src.y.into() * half);
         let (s_z, c_z) = Rad::sin_cos(src.z.into() * half);
 
-        Quaternion::new(c_y * c_x * c_z - s_y * s_x * s_z,
-                        s_y * s_x * c_z + c_y * c_x * s_z,
-                        s_y * c_x * c_z + c_y * s_x * s_z,
-                        c_y * s_x * c_z - s_y * c_x * s_z)
+        Quaternion::new(-s_x * s_y * s_z + c_x * c_y * c_z,
+                         s_x * c_y * c_z + s_y * s_z * c_x,
+                        -s_x * s_z * c_y + s_y * c_x * c_z,
+                         s_x * s_y * c_z + s_z * c_x * c_y)
     }
 }
 

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -72,6 +72,8 @@ pub trait Rotation3<S: BaseFloat>: Rotation<Point3<S>>
                                  + Into<Quaternion<S>>
                                  + From<Euler<Rad<S>>> {
     /// Create a rotation using an angle around a given axis.
+    ///
+    /// The specified axis **must be normalized**, or it represents an invalid rotation.
     fn from_axis_angle(axis: Vector3<S>, angle: Rad<S>) -> Self;
 
     /// Create a rotation from an angle around the `x` axis (pitch).

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -398,6 +398,115 @@ pub mod matrix3 {
             #[test] fn test_neg_1()     { check_from_axis_angle_z(rad(-1.0)); }
         }
     }
+
+    mod rotate_from_euler {
+        use cgmath::*;
+
+        #[test]
+        fn test_x() {
+            let vec = vec3(0.0, 0.0, 1.0);
+
+            let rot = Matrix3::from(Euler::new(deg(90.0).into(), rad(0.0), rad(0.0)));
+            assert_approx_eq!(vec3(0.0, -1.0, 0.0), rot * vec);
+
+            let rot = Matrix3::from(Euler::new(deg(-90.0).into(), rad(0.0), rad(0.0)));
+            assert_approx_eq!(vec3(0.0, 1.0, 0.0), rot * vec);
+        }
+
+        #[test]
+        fn test_y() {
+            let vec = vec3(0.0, 0.0, 1.0);
+
+            let rot = Matrix3::from(Euler::new(rad(0.0), deg(90.0).into(), rad(0.0)));
+            assert_approx_eq!(vec3(1.0, 0.0, 0.0), rot * vec);
+
+            let rot = Matrix3::from(Euler::new(rad(0.0), deg(-90.0).into(), rad(0.0)));
+            assert_approx_eq!(vec3(-1.0, 0.0, 0.0), rot * vec);
+        }
+
+        #[test]
+        fn test_z() {
+            let vec = vec3(1.0, 0.0, 0.0);
+
+            let rot = Matrix3::from(Euler::new(rad(0.0), rad(0.0), deg(90.0).into()));
+            assert_approx_eq!(vec3(0.0, 1.0, 0.0), rot * vec);
+
+            let rot = Matrix3::from(Euler::new(rad(0.0), rad(0.0), deg(-90.0).into()));
+            assert_approx_eq!(vec3(0.0, -1.0, 0.0), rot * vec);
+        }
+
+
+        // tests that the Y rotation is done after the X
+        #[test]
+        fn test_x_then_y() {
+            let vec = vec3(0.0, 1.0, 0.0);
+
+            let rot = Matrix3::from(Euler::new(deg(90.0).into(), deg(90.0).into(), rad(0.0)));
+            assert_approx_eq!(vec3(0.0, 0.0, 1.0), rot * vec);
+        }
+
+        // tests that the Z rotation is done after the Y
+        #[test]
+        fn test_y_then_z() {
+            let vec = vec3(0.0, 0.0, 1.0);
+
+            let rot = Matrix3::from(Euler::new(rad(0.0), deg(90.0).into(), deg(90.0).into()));
+            assert_approx_eq!(vec3(1.0, 0.0, 0.0), rot * vec);
+        }
+    }
+
+    mod rotate_from_axis_angle {
+        use cgmath::*;
+
+        #[test]
+        fn test_x() {
+            let vec = vec3(0.0, 0.0, 1.0);
+
+            let rot = Matrix3::from_angle_x(deg(90.0).into());
+            println!("x mat: {:?}", rot);
+            assert_approx_eq!(vec3(0.0, -1.0, 0.0), rot * vec);
+        }
+
+        #[test]
+        fn test_y() {
+            let vec = vec3(0.0, 0.0, 1.0);
+
+            let rot = Matrix3::from_angle_y(deg(90.0).into());
+            assert_approx_eq!(vec3(1.0, 0.0, 0.0), rot * vec);
+        }
+
+        #[test]
+        fn test_z() {
+            let vec = vec3(1.0, 0.0, 0.0);
+
+            let rot = Matrix3::from_angle_z(deg(90.0).into());
+            assert_approx_eq!(vec3(0.0, 1.0, 0.0), rot * vec);
+        }
+
+        #[test]
+        fn test_xy() {
+            let vec = vec3(0.0, 0.0, 1.0);
+
+            let rot = Matrix3::from_axis_angle(vec3(1.0, 1.0, 0.0).normalize(), deg(90.0).into());
+            assert_approx_eq!(vec3(2.0f32.sqrt() / 2.0, -2.0f32.sqrt() / 2.0, 0.0), rot * vec);
+        }
+
+        #[test]
+        fn test_yz() {
+            let vec = vec3(1.0, 0.0, 0.0);
+
+            let rot = Matrix3::from_axis_angle(vec3(0.0, 1.0, 1.0).normalize(), deg(-90.0).into());
+            assert_approx_eq!(vec3(0.0, -2.0f32.sqrt() / 2.0, 2.0f32.sqrt() / 2.0), rot * vec);
+        }
+
+        #[test]
+        fn test_xz() {
+            let vec = vec3(0.0, 1.0, 0.0);
+
+            let rot = Matrix3::from_axis_angle(vec3(1.0, 0.0, 1.0).normalize(), deg(90.0).into());
+            assert_approx_eq!(vec3(-2.0f32.sqrt() / 2.0, 0.0, 2.0f32.sqrt() / 2.0), rot * vec);
+        }
+    }
 }
 
 pub mod matrix4 {

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -168,3 +168,55 @@ mod rotate_from_euler {
         assert_approx_eq!(vec3(1.0, 0.0, 0.0), rot * vec);
     }
 }
+
+mod rotate_from_axis_angle {
+    use cgmath::*;
+
+    #[test]
+    fn test_x() {
+        let vec = vec3(0.0, 0.0, 1.0);
+
+        let rot = Quaternion::from_angle_x(deg(90.0).into());
+        assert_approx_eq!(vec3(0.0, -1.0, 0.0), rot * vec);
+    }
+
+    #[test]
+    fn test_y() {
+        let vec = vec3(0.0, 0.0, 1.0);
+
+        let rot = Quaternion::from_angle_y(deg(90.0).into());
+        assert_approx_eq!(vec3(1.0, 0.0, 0.0), rot * vec);
+    }
+
+    #[test]
+    fn test_z() {
+        let vec = vec3(1.0, 0.0, 0.0);
+
+        let rot = Quaternion::from_angle_z(deg(90.0).into());
+        assert_approx_eq!(vec3(0.0, 1.0, 0.0), rot * vec);
+    }
+
+    #[test]
+    fn test_xy() {
+        let vec = vec3(0.0, 0.0, 1.0);
+
+        let rot = Quaternion::from_axis_angle(vec3(1.0, 1.0, 0.0).normalize(), deg(90.0).into());
+        assert_approx_eq!(vec3(2.0f32.sqrt() / 2.0, -2.0f32.sqrt() / 2.0, 0.0), rot * vec);
+    }
+
+    #[test]
+    fn test_yz() {
+        let vec = vec3(1.0, 0.0, 0.0);
+
+        let rot = Quaternion::from_axis_angle(vec3(0.0, 1.0, 1.0).normalize(), deg(-90.0).into());
+        assert_approx_eq!(vec3(0.0, -2.0f32.sqrt() / 2.0, 2.0f32.sqrt() / 2.0), rot * vec);
+    }
+
+    #[test]
+    fn test_xz() {
+        let vec = vec3(0.0, 1.0, 0.0);
+
+        let rot = Quaternion::from_axis_angle(vec3(1.0, 0.0, 1.0).normalize(), deg(90.0).into());
+        assert_approx_eq!(vec3(-2.0f32.sqrt() / 2.0, 0.0, 2.0f32.sqrt() / 2.0), rot * vec);
+    }
+}

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -112,3 +112,59 @@ mod from {
         }
     }
 }
+
+mod rotate_from_euler {
+    use cgmath::*;
+
+    #[test]
+    fn test_x() {
+        let vec = vec3(0.0, 0.0, 1.0);
+
+        let rot = Quaternion::from(Euler::new(deg(90.0).into(), rad(0.0), rad(0.0)));
+        assert_approx_eq!(vec3(0.0, -1.0, 0.0), rot * vec);
+
+        let rot = Quaternion::from(Euler::new(deg(-90.0).into(), rad(0.0), rad(0.0)));
+        assert_approx_eq!(vec3(0.0, 1.0, 0.0), rot * vec);
+    }
+
+    #[test]
+    fn test_y() {
+        let vec = vec3(0.0, 0.0, 1.0);
+
+        let rot = Quaternion::from(Euler::new(rad(0.0), deg(90.0).into(), rad(0.0)));
+        assert_approx_eq!(vec3(1.0, 0.0, 0.0), rot * vec);
+
+        let rot = Quaternion::from(Euler::new(rad(0.0), deg(-90.0).into(), rad(0.0)));
+        assert_approx_eq!(vec3(-1.0, 0.0, 0.0), rot * vec);
+    }
+
+    #[test]
+    fn test_z() {
+        let vec = vec3(1.0, 0.0, 0.0);
+
+        let rot = Quaternion::from(Euler::new(rad(0.0), rad(0.0), deg(90.0).into()));
+        assert_approx_eq!(vec3(0.0, 1.0, 0.0), rot * vec);
+
+        let rot = Quaternion::from(Euler::new(rad(0.0), rad(0.0), deg(-90.0).into()));
+        assert_approx_eq!(vec3(0.0, -1.0, 0.0), rot * vec);
+    }
+
+
+    // tests that the Y rotation is done after the X
+    #[test]
+    fn test_x_then_y() {
+        let vec = vec3(0.0, 1.0, 0.0);
+
+        let rot = Quaternion::from(Euler::new(deg(90.0).into(), deg(90.0).into(), rad(0.0)));
+        assert_approx_eq!(vec3(0.0, 0.0, 1.0), rot * vec);
+    }
+
+    // tests that the Z rotation is done after the Y
+    #[test]
+    fn test_y_then_z() {
+        let vec = vec3(0.0, 0.0, 1.0);
+
+        let rot = Quaternion::from(Euler::new(rad(0.0), deg(90.0).into(), deg(90.0).into()));
+        assert_approx_eq!(vec3(1.0, 0.0, 0.0), rot * vec);
+    }
+}


### PR DESCRIPTION
Fixes #285 and maybe #143.

I just started learning 3D graphics and ran into #285, but since I have some past experience with Euler angles and quaternions, I tried fixing it.

I started by adding tests. These tests used to fail and now pass:

- rotate_from_euler::test_x
- rotate_from_euler::test_z
- rotate_from_euler::test_y_then_z
- matrix3::rotate_from_euler::test_x_then_y
- matrix3::rotate_from_euler::test_y_then_z

I'm pretty sure the equations in #290 are wrong because Euclidean Space uses YXZ Euler angles, but cgmath is using XYZ. Reordering the angles does not give the right answer (and since axis angle to quaternion conversion currently works correctly, the hack to fix axis angles is incorrect and an indication the other equations are wrong). This NASA document gives equations for all Euler angle sequences:

http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf

The equations that took the most work were the Euler angles to quaternion. I had to derive those equations because they aren't in the document, and Euclidean Space and Wikipedia have them in a different order than XYZ. Airplanes usually use ZYX, so that's what Wikipedia's equations are for. I'm fairly confident all the equations are correct, but I would appreciate any double checking.

What do you think of removing from the documentation any mention of roll, pitch, and yaw? Users can orient their axes however they want and even use a left-handed or right-handed coordinate system and cgmath will work fine.

If they are using it with a game engine with different axes, pitch, yaw, and roll may not correspond to x, y, and z, and calling them that in the docs could be confusing. For example, I'm using X right, Y away, and Z up, the same as Blender and CryEngine, because I think it makes more sense (but it means yaw is Z, not Y).
