### PR TITLE
Adds nightly serde support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ rust:
 
 env:
   global:
-    secure: afYeHpC8BJeyajd3vd84xRBYJKxQorKfh4lGvesu/hqh0bHc6lxrqGt0Pthb2m2YDODZiGSbx9yr9UetelZIJUSA3LoiG5PdDrtH/Kwdn5xGcBWSZl3v/sH+oB3AeR7Eji6mj0mrydQxn8PQbEACvR6lpGCYE2R48KrftYmD6Js=
+    - TRAVIS_CARGO_NIGHTLY_FEATURE="eders"
+    - secure: afYeHpC8BJeyajd3vd84xRBYJKxQorKfh4lGvesu/hqh0bHc6lxrqGt0Pthb2m2YDODZiGSbx9yr9UetelZIJUSA3LoiG5PdDrtH/Kwdn5xGcBWSZl3v/sH+oB3AeR7Eji6mj0mrydQxn8PQbEACvR6lpGCYE2R48KrftYmD6Js=
 
 before_script:
   - |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ serde_macros = { version = "0.7", optional = true }
 
 [dev-dependencies]
 glium = "0.14.0"
+serde_json = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,14 @@ name = "cgmath"
 [features]
 unstable = []
 default = ["rustc-serialize"]
+eders = ["serde", "serde_macros"]
 
 [dependencies]
 num-traits = "0.1"
 rand = "0.3"
 rustc-serialize = { version = "0.3", optional = true }
+serde = { version = "0.7", optional = true }
+serde_macros = { version = "0.7", optional = true }
 
 [dev-dependencies]
 glium = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,12 @@ name = "cgmath"
 
 [features]
 unstable = []
+default = ["rustc-serialize"]
 
 [dependencies]
 num-traits = "0.1"
 rand = "0.3"
-rustc-serialize = "0.3"
+rustc-serialize = { version = "0.3", optional = true }
 
 [dev-dependencies]
 glium = "0.14.0"

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -32,14 +32,16 @@ use num::BaseFloat;
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq, PartialOrd, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Rad<S> { pub s: S }
 
 /// An angle, in degrees.
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq, PartialOrd, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Deg<S> { pub s: S }
 
 /// Create a new angle, in radians

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -34,6 +34,7 @@ use num::BaseFloat;
 #[repr(C, packed)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Rad<S> { pub s: S }
 
 /// An angle, in degrees.
@@ -42,6 +43,7 @@ pub struct Rad<S> { pub s: S }
 #[repr(C, packed)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Deg<S> { pub s: S }
 
 /// Create a new angle, in radians

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -65,6 +65,7 @@ use num::BaseFloat;
 #[derive(Copy, Clone, Debug)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Euler<A: Angle> {
     /// The angle to apply around the _x_ axis. Also known at the _pitch_.
     pub x: A,

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -64,7 +64,7 @@ use num::BaseFloat;
 #[repr(C, packed)]
 #[derive(Copy, Clone, Debug)]
 #[derive(PartialEq, Eq)]
-#[derive(RustcEncodable, RustcDecodable)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Euler<A: Angle> {
     /// The angle to apply around the _x_ axis. Also known at the _pitch_.
     pub x: A,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,10 @@
 //! ```
 
 pub extern crate num_traits;
-extern crate rustc_serialize;
 extern crate rand;
+
+#[cfg(feature = "rustc-serialize")]
+extern crate rustc_serialize;
 
 // Re-exports
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,17 @@
 //! use cgmath::prelude::*;
 //! ```
 
+#![cfg_attr(feature = "eders", feature(plugin, custom_derive))]
+#![cfg_attr(feature = "eders", plugin(serde_macros))]
+
 pub extern crate num_traits;
 extern crate rand;
 
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
+
+#[cfg(feature = "eders")]
+extern crate serde;
 
 // Re-exports
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -37,6 +37,7 @@ use vector::{Vector2, Vector3, Vector4};
 #[repr(C, packed)]
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Matrix2<S> {
     /// The first column of the matrix.
     pub x: Vector2<S>,
@@ -50,6 +51,7 @@ pub struct Matrix2<S> {
 #[repr(C, packed)]
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Matrix3<S> {
     /// The first column of the matrix.
     pub x: Vector3<S>,
@@ -65,6 +67,7 @@ pub struct Matrix3<S> {
 #[repr(C, packed)]
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Matrix4<S> {
     /// The first column of the matrix.
     pub x: Vector4<S>,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -35,7 +35,8 @@ use vector::{Vector2, Vector3, Vector4};
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Matrix2<S> {
     /// The first column of the matrix.
     pub x: Vector2<S>,
@@ -47,7 +48,8 @@ pub struct Matrix2<S> {
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Matrix3<S> {
     /// The first column of the matrix.
     pub x: Vector3<S>,
@@ -61,7 +63,8 @@ pub struct Matrix3<S> {
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Matrix4<S> {
     /// The first column of the matrix.
     pub x: Vector4<S>,

--- a/src/point.rs
+++ b/src/point.rs
@@ -33,6 +33,7 @@ use vector::{Vector1, Vector2, Vector3, Vector4};
 #[repr(C, packed)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Point1<S> {
     pub x: S,
 }
@@ -43,6 +44,7 @@ pub struct Point1<S> {
 #[repr(C, packed)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Point2<S> {
     pub x: S,
     pub y: S,
@@ -54,6 +56,7 @@ pub struct Point2<S> {
 #[repr(C, packed)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Point3<S> {
     pub x: S,
     pub y: S,

--- a/src/point.rs
+++ b/src/point.rs
@@ -31,7 +31,8 @@ use vector::{Vector1, Vector2, Vector3, Vector4};
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Point1<S> {
     pub x: S,
 }
@@ -40,7 +41,8 @@ pub struct Point1<S> {
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Point2<S> {
     pub x: S,
     pub y: S,
@@ -50,7 +52,8 @@ pub struct Point2<S> {
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Point3<S> {
     pub x: S,
     pub y: S,

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -66,7 +66,8 @@ pub fn ortho<S: BaseFloat>(left: S, right: S, bottom: S, top: S, near: S, far: S
 }
 
 /// A perspective projection based on a vertical field-of-view angle.
-#[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct PerspectiveFov<S> {
     pub fovy:   Rad<S>,
     pub aspect: S,
@@ -132,7 +133,8 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
 }
 
 /// A perspective projection with arbitrary left/right/bottom/top distances
-#[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Perspective<S> {
     pub left:   S,
     pub right:  S,
@@ -178,7 +180,8 @@ impl<S: BaseFloat> From<Perspective<S>> for Matrix4<S> {
 }
 
 /// An orthographic projection with arbitrary left/right/bottom/top distances
-#[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Ortho<S> {
     pub left:   S,
     pub right:  S,

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -68,6 +68,7 @@ pub fn ortho<S: BaseFloat>(left: S, right: S, bottom: S, top: S, near: S, far: S
 /// A perspective projection based on a vertical field-of-view angle.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct PerspectiveFov<S> {
     pub fovy:   Rad<S>,
     pub aspect: S,
@@ -135,6 +136,7 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
 /// A perspective projection with arbitrary left/right/bottom/top distances
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Perspective<S> {
     pub left:   S,
     pub right:  S,
@@ -182,6 +184,7 @@ impl<S: BaseFloat> From<Perspective<S>> for Matrix4<S> {
 /// An orthographic projection with arbitrary left/right/bottom/top distances
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Ortho<S> {
     pub left:   S,
     pub right:  S,

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -38,6 +38,7 @@ use vector::Vector3;
 #[repr(C, packed)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Quaternion<S> {
     /// The scalar part of the quaternion.
     pub s: S,

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -36,7 +36,8 @@ use vector::Vector3;
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Quaternion<S> {
     /// The scalar part of the quaternion.
     pub s: S,

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -137,7 +137,8 @@ pub trait Rotation3<S: BaseFloat>: Rotation<Point3<S>>
 /// let unit_y3 = (rot_half * rot_half).rotate_vector(unit_x);
 /// assert!(unit_y3.approx_eq(&unit_y2));
 /// ```
-#[derive(PartialEq, Copy, Clone, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Basis2<S> {
     mat: Matrix2<S>
 }
@@ -209,7 +210,8 @@ impl<S: fmt::Debug> fmt::Debug for Basis2<S> {
 /// inversion, can be implemented more efficiently than the implementations for
 /// `math::Matrix3`. To ensure orthogonality is maintained, the operations have
 /// been restricted to a subeset of those implemented on `Matrix3`.
-#[derive(PartialEq, Copy, Clone, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Basis3<S> {
     mat: Matrix3<S>
 }

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -139,6 +139,7 @@ pub trait Rotation3<S: BaseFloat>: Rotation<Point3<S>>
 /// ```
 #[derive(PartialEq, Copy, Clone)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Basis2<S> {
     mat: Matrix2<S>
 }
@@ -212,6 +213,7 @@ impl<S: fmt::Debug> fmt::Debug for Basis2<S> {
 /// been restricted to a subeset of those implemented on `Matrix3`.
 #[derive(PartialEq, Copy, Clone)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Basis3<S> {
     mat: Matrix3<S>
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -148,3 +148,150 @@ impl<S: BaseFloat, R: Rotation3<S>> From<Decomposed<Vector3<S>, R>> for Matrix4<
 impl<S: BaseFloat, R: Rotation2<S>> Transform2<S> for Decomposed<Vector2<S>, R> {}
 
 impl<S: BaseFloat, R: Rotation3<S>> Transform3<S> for Decomposed<Vector3<S>, R> {}
+
+#[cfg(feature = "eders")]
+#[doc(hidden)]
+mod eders_ser {
+    use structure::VectorSpace;
+    use super::Decomposed;
+    use serde::{self, Serialize};
+
+    impl<V: VectorSpace, R> Serialize for Decomposed<V, R>
+        where V: Serialize, V::Scalar: Serialize, R: Serialize
+    {
+        fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+            where S: serde::Serializer
+        {
+            serializer.serialize_struct("Decomposed", DecomposedVisitor {
+                value: self,
+                state: 0,
+            })
+        }
+    }
+
+    struct DecomposedVisitor<'a, V: 'a + VectorSpace, R: 'a> {
+        value: &'a Decomposed<V, R>,
+        state: u8,
+    }
+
+    impl<'a, V: 'a + VectorSpace, R> serde::ser::MapVisitor for DecomposedVisitor<'a, V, R>
+        where V: Serialize, V::Scalar: Serialize, R: Serialize
+    {
+        fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
+            where S: serde::Serializer
+        {
+            match self.state {
+                0 => {
+                    self.state += 1;
+                    Ok(Some(try!(serializer.serialize_struct_elt("scale", &self.value.scale))))
+                },
+                1 => {
+                    self.state += 1;
+                    Ok(Some(try!(serializer.serialize_struct_elt("rot", &self.value.rot))))
+                },
+                2 => {
+                    self.state += 1;
+                    Ok(Some(try!(serializer.serialize_struct_elt("disp", &self.value.disp))))
+                },
+                _ => {
+                    Ok(None)
+                },
+            }
+        }
+    }
+}
+
+#[cfg(feature = "eders")]
+#[doc(hidden)]
+mod eders_de {
+    use structure::VectorSpace;
+    use super::Decomposed;
+    use serde::{self, Deserialize};
+    use std::marker::PhantomData;
+
+    enum DecomposedField {
+        Scale,
+        Rot,
+        Disp,
+    }
+
+    impl Deserialize for DecomposedField {
+        fn deserialize<D>(deserializer: &mut D) -> Result<DecomposedField, D::Error>
+            where D: serde::Deserializer
+        {
+            struct DecomposedFieldVisitor;
+
+            impl serde::de::Visitor for DecomposedFieldVisitor {
+                type Value = DecomposedField;
+
+                fn visit_str<E>(&mut self, value: &str) -> Result<DecomposedField, E>
+                    where E: serde::de::Error
+                {
+                    match value {
+                        "scale" => Ok(DecomposedField::Scale),
+                        "rot" => Ok(DecomposedField::Rot),
+                        "disp" => Ok(DecomposedField::Disp),
+                        _ => Err(serde::de::Error::custom("expected scale, rot or disp")),
+                    }
+                }
+            }
+
+            deserializer.deserialize(DecomposedFieldVisitor)
+        }
+    }
+
+    impl<S: VectorSpace, R> Deserialize for Decomposed<S, R>
+        where S: Deserialize, S::Scalar: Deserialize, R: Deserialize
+    {
+        fn deserialize<D>(deserializer: &mut D) -> Result<Decomposed<S, R>, D::Error>
+            where D: serde::de::Deserializer
+        {
+            const FIELDS: &'static [&'static str] = &["scale", "rot", "disp"];
+            deserializer.deserialize_struct("Decomposed", FIELDS, DecomposedVisitor(PhantomData))
+        }
+    }
+
+    struct DecomposedVisitor<S: VectorSpace, R>(PhantomData<(S, R)>);
+
+    impl<S: VectorSpace, R> serde::de::Visitor for DecomposedVisitor<S, R>
+        where S: Deserialize, S::Scalar: Deserialize, R: Deserialize
+    {
+        type Value = Decomposed<S, R>;
+
+        fn visit_map<V>(&mut self, mut visitor: V) -> Result<Decomposed<S, R>, V::Error>
+            where V: serde::de::MapVisitor
+        {
+            let mut scale = None;
+            let mut rot = None;
+            let mut disp = None;
+
+            loop {
+                match try!(visitor.visit_key()) {
+                    Some(DecomposedField::Scale) => { scale = Some(try!(visitor.visit_value())); },
+                    Some(DecomposedField::Rot) => { rot = Some(try!(visitor.visit_value())); },
+                    Some(DecomposedField::Disp) => { disp = Some(try!(visitor.visit_value())); },
+                    _ => { break; },
+                }
+            }
+
+            let scale = match scale {
+                Some(scale) => scale,
+                None => try!(visitor.missing_field("scale")),
+            };
+
+            let rot = match rot {
+                Some(rot) => rot,
+                None => try!(visitor.missing_field("rot")),
+            };
+
+            let disp = match disp {
+                Some(disp) => disp,
+                None => try!(visitor.missing_field("disp")),
+            };
+
+            try!(visitor.end());
+
+            Ok(Decomposed { scale: scale, rot: rot, disp: disp })
+        }
+    }
+}

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -56,7 +56,8 @@ pub trait Transform<P: EuclideanSpace>: Sized {
 
 /// A generic transformation consisting of a rotation,
 /// displacement vector and scale amount.
-#[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Decomposed<V: VectorSpace, R> {
     pub scale: V::Scalar,
     pub rot: R,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -149,6 +149,18 @@ impl<S: BaseFloat, R: Rotation2<S>> Transform2<S> for Decomposed<Vector2<S>, R> 
 
 impl<S: BaseFloat, R: Rotation3<S>> Transform3<S> for Decomposed<Vector3<S>, R> {}
 
+impl<S: VectorSpace, R, E: BaseFloat> ApproxEq for Decomposed<S, R>
+    where S: ApproxEq<Epsilon = E>, S::Scalar: ApproxEq<Epsilon = E>, R: ApproxEq<Epsilon = E>
+{
+    type Epsilon = E;
+
+    fn approx_eq_eps(&self, other: &Self, epsilon: &Self::Epsilon) -> bool {
+        self.scale.approx_eq_eps(&other.scale, epsilon) &&
+        self.rot.approx_eq_eps(&other.rot, epsilon) &&
+        self.disp.approx_eq_eps(&other.disp, epsilon)
+    }
+}
+
 #[cfg(feature = "eders")]
 #[doc(hidden)]
 mod eders_ser {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -31,6 +31,7 @@ use num::{BaseNum, BaseFloat, PartialOrd};
 #[repr(C, packed)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Vector1<S> {
     /// The x component of the vector.
     pub x: S,
@@ -42,6 +43,7 @@ pub struct Vector1<S> {
 #[repr(C, packed)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Vector2<S> {
     /// The x component of the vector.
     pub x: S,
@@ -55,6 +57,7 @@ pub struct Vector2<S> {
 #[repr(C, packed)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Vector3<S> {
     /// The x component of the vector.
     pub x: S,
@@ -70,6 +73,7 @@ pub struct Vector3<S> {
 #[repr(C, packed)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Vector4<S> {
     /// The x component of the vector.
     pub x: S,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -29,7 +29,8 @@ use num::{BaseNum, BaseFloat, PartialOrd};
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Vector1<S> {
     /// The x component of the vector.
     pub x: S,
@@ -39,7 +40,8 @@ pub struct Vector1<S> {
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Vector2<S> {
     /// The x component of the vector.
     pub x: S,
@@ -51,7 +53,8 @@ pub struct Vector2<S> {
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Vector3<S> {
     /// The x component of the vector.
     pub x: S,
@@ -65,7 +68,8 @@ pub struct Vector3<S> {
 ///
 /// This type is marked as `#[repr(C, packed)]`.
 #[repr(C, packed)]
-#[derive(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Vector4<S> {
     /// The x component of the vector.
     pub x: S,

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -16,28 +16,46 @@
 
 extern crate cgmath;
 
+#[cfg(feature = "eders")]
+extern crate serde_json;
+
 use cgmath::*;
 
 #[test]
 fn test_invert() {
-	let v = Vector3::new(1.0f64, 2.0, 3.0);
-	let t = Decomposed {
+    let v = Vector3::new(1.0f64, 2.0, 3.0);
+    let t = Decomposed {
         scale: 1.5f64,
-        rot: Quaternion::new(0.5f64,0.5,0.5,0.5),
-        disp: Vector3::new(6.0f64,-7.0,8.0)
+        rot: Quaternion::new(0.5f64, 0.5, 0.5, 0.5),
+        disp: Vector3::new(6.0f64, -7.0, 8.0),
     };
-	let ti = t.inverse_transform().expect("Expected successful inversion");
-	let vt = t.transform_vector(v);
+    let ti = t.inverse_transform().expect("Expected successful inversion");
+    let vt = t.transform_vector(v);
     assert!(v.approx_eq(&ti.transform_vector(vt)));
 }
 
 #[test]
 fn test_look_at() {
-	let eye = Point3::new(0.0f64, 0.0, -5.0);
-	let center = Point3::new(0.0f64, 0.0, 0.0);
-	let up = Vector3::new(1.0f64, 0.0, 0.0);
-	let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at(eye, center, up);
-	let point = Point3::new(1.0f64, 0.0, 0.0);
-	let view_point = Point3::new(0.0f64, 1.0, 5.0);
-	assert!(t.transform_point(point).approx_eq(&view_point));
+    let eye = Point3::new(0.0f64, 0.0, -5.0);
+    let center = Point3::new(0.0f64, 0.0, 0.0);
+    let up = Vector3::new(1.0f64, 0.0, 0.0);
+    let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at(eye, center, up);
+    let point = Point3::new(1.0f64, 0.0, 0.0);
+    let view_point = Point3::new(0.0f64, 1.0, 5.0);
+    assert!(t.transform_point(point).approx_eq(&view_point));
+}
+
+#[cfg(feature = "eders")]
+#[test]
+fn test_serialize() {
+    let t = Decomposed {
+        scale: 1.5f64,
+        rot: Quaternion::new(0.5f64, 0.5, 0.5, 0.5),
+        disp: Vector3::new(6.0f64, -7.0, 8.0),
+    };
+
+    let serialized = serde_json::to_string(&t).unwrap();
+    let deserialized: Decomposed<Vector3<f64>, Quaternion<f64>> = serde_json::from_str(&serialized).unwrap();
+
+    assert!(t.approx_eq(&deserialized));
 }


### PR DESCRIPTION
There is a few things to note:
- I made `rustc-serialize` dependency optional to allow choosing between the two crates.

- Serde macros does not seem to support associated types. I had to implement the trait manually for `Decomposed`

- I did not use `syntex` for stable rust support as I was unsure how to handle the build configuration with both `serde_macros` and `serde_codegen` as optional dependencies.

Closes #313